### PR TITLE
Website styling updates (Thoth Tech T2 2024)

### DIFF
--- a/src/content/docs/api/index.mdx
+++ b/src/content/docs/api/index.mdx
@@ -5,7 +5,7 @@ sidebar:
 ---
 
 
-:::tip[Components]
+:::tip[SplashKit SDK]
 
 SplashKit provides a versatile set of categories, encompassing graphics, audio, input, and more, offering developers a comprehensive toolkit for game and multimedia development.
 

--- a/src/content/docs/guides/index.mdx
+++ b/src/content/docs/guides/index.mdx
@@ -6,7 +6,7 @@ sidebar:
 ---
 
 
-:::tip[Components]
+:::tip[SplashKit SDK]
 
 SplashKit provides a versatile set of categories, encompassing graphics, audio, input, and more, offering developers a comprehensive toolkit for game and multimedia development.
 

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -15,7 +15,8 @@ hero:
       variant: primary
     - text: Article & Guides
       link: /guides/
-      icon: external
+      icon: right-arrow
+      variant: secondary
 ---
 
 

--- a/src/content/docs/installation/Linux/step-1.md
+++ b/src/content/docs/installation/Linux/step-1.md
@@ -2,8 +2,8 @@
 title: Install Command Line Tools
 sidebar:
   label: 1. Command Line Tools
-  attrs:
-    class: linux
+  # attrs:
+  #   class: linux
 ---
 
 To install SplashKit, you will firstly need to install some command line tools using the apt or apt-get package manager.

--- a/src/content/docs/installation/Linux/step-2.md
+++ b/src/content/docs/installation/Linux/step-2.md
@@ -2,8 +2,8 @@
 title: Install SplashKit
 sidebar:
   label: 2. SplashKit
-  attrs:
-    class: linux
+#   attrs:
+#     class: linux
 ---
 
 Once you have installed the [Command Line Tools](/installation/linux/step-1/) you can install SplashKit and build the SplashKit library from its source.

--- a/src/content/docs/installation/Linux/step-3.md
+++ b/src/content/docs/installation/Linux/step-3.md
@@ -2,8 +2,8 @@
 title: Install Visual Studio Code
 sidebar:
   label: 3. Visual Studio Code
-  attrs:
-    class: linux
+#   attrs:
+#     class: linux
 ---
 
 Once you have the [built splashkit](/installation/linux/step-3/) you

--- a/src/content/docs/installation/Linux/step-4.md
+++ b/src/content/docs/installation/Linux/step-4.md
@@ -2,8 +2,8 @@
 title: Install Language Specific Tools
 sidebar:
   label: 4. Language Tools
-  attrs:
-    class: linux
+  # attrs:
+  #   class: linux
 ---
 
 SplashKit works with a number of programming languages.

--- a/src/content/docs/installation/MacOS/step-1.md
+++ b/src/content/docs/installation/MacOS/step-1.md
@@ -2,8 +2,8 @@
 title: Install Xcode Command Line Tools
 sidebar:
   label: 1. Command Line Tools
-  attrs:
-    class: apple
+  # attrs:
+  #   class: apple
 ---
 
 The Command Line Tools provided by Xcode provide a large amount of developer

--- a/src/content/docs/installation/MacOS/step-2.md
+++ b/src/content/docs/installation/MacOS/step-2.md
@@ -2,8 +2,8 @@
 title: Install SplashKit
 sidebar:
   label: 2. SplashKit
-  attrs:
-    class: apple
+#   attrs:
+#     class: apple
 ---
 
 [SplashKit](https://splashkit.io) is a beginner's all-purpose software toolkit that will allow you to create fun and exciting programs more easily, especially for Graphical User Interface (GUI) programs.

--- a/src/content/docs/installation/MacOS/step-3.md
+++ b/src/content/docs/installation/MacOS/step-3.md
@@ -2,8 +2,8 @@
 title: Install Visual Studio Code
 sidebar:
   label: 3. Visual Studio Code
-  attrs:
-    class: apple
+  # attrs:
+  #   class: apple
 ---
 
 Visual Studio Code, also commonly known as *VS Code* or just *Code*, is a powerful and versatile code editor that enables efficient coding, debugging, and collaboration for your SplashKit projects!

--- a/src/content/docs/installation/MacOS/step-4.md
+++ b/src/content/docs/installation/MacOS/step-4.md
@@ -2,8 +2,8 @@
 title: Install Language Specific Tools
 sidebar:
   label: 4. Language Tools
-  attrs:
-    class: apple
+  # attrs:
+  #   class: apple
 ---
 
 SplashKit works with a number of programming languages.

--- a/src/content/docs/installation/Windows (MSYS2)/step-1.md
+++ b/src/content/docs/installation/Windows (MSYS2)/step-1.md
@@ -2,8 +2,8 @@
 title: Install MSYS2 and Command Line Tools
 sidebar:
   label: 1. MSYS2 and Command Line Tools
-  attrs:
-    class: windows
+  # attrs:
+  #   class: windows
 ---
 
 MSYS2 provide a unix terminal environment for Windows. We will need this to run the build commands to create our SplashKit programs.

--- a/src/content/docs/installation/Windows (MSYS2)/step-2.md
+++ b/src/content/docs/installation/Windows (MSYS2)/step-2.md
@@ -2,8 +2,8 @@
 title: Install SplashKit
 sidebar:
   label: 2. SplashKit
-  attrs:
-    class: windows
+#   attrs:
+#     class: windows
 ---
 
 Once you have MSYS2 installed, you can install the SplashKit library:

--- a/src/content/docs/installation/Windows (MSYS2)/step-3.md
+++ b/src/content/docs/installation/Windows (MSYS2)/step-3.md
@@ -2,8 +2,8 @@
 title: Install Visual Studio Code
 sidebar:
   label: 3. Visual Studio Code
-  attrs:
-    class: windows
+  # attrs:
+  #   class: windows
 ---
 
 Visual Studio Code, also commonly known as *VS Code* or just *Code*, is a powerful and versatile code editor that enables efficient coding, debugging, and collaboration for your SplashKit projects!

--- a/src/content/docs/installation/Windows (MSYS2)/step-4.md
+++ b/src/content/docs/installation/Windows (MSYS2)/step-4.md
@@ -2,8 +2,8 @@
 title: Install Language Specific Tools
 sidebar:
   label: 4. Language Tools
-  attrs:
-    class: windows
+  # attrs:
+  #   class: windows
 ---
 
 ## Steps

--- a/src/content/docs/installation/Windows (WSL)/index.mdx
+++ b/src/content/docs/installation/Windows (WSL)/index.mdx
@@ -3,7 +3,7 @@ title: Windows (WSL) Installation Overview
 sidebar:
   label: Overview
   attrs:
-    class: windows
+    class: windows-wsl
 ---
 To get SplashKit installed on Windows, follow the four steps:
 

--- a/src/content/docs/installation/Windows (WSL)/step-1.md
+++ b/src/content/docs/installation/Windows (WSL)/step-1.md
@@ -2,8 +2,8 @@
 title: Install WSL and Command Line Tools
 sidebar:
   label: 1. WSL and Command Line Tools
-  attrs:
-    class: windows
+  # attrs:
+  #   class: windows-wsl
 ---
 
 ## Install WSL (Ubuntu)

--- a/src/content/docs/installation/Windows (WSL)/step-2.md
+++ b/src/content/docs/installation/Windows (WSL)/step-2.md
@@ -2,8 +2,8 @@
 title: Install SplashKit
 sidebar:
   label: 2. SplashKit
-  attrs:
-    class: windows
+#   attrs:
+#     class: windows-wsl
 ---
 
 Once you have WSL installed, you can install the SplashKit library:

--- a/src/content/docs/installation/Windows (WSL)/step-3.md
+++ b/src/content/docs/installation/Windows (WSL)/step-3.md
@@ -2,8 +2,8 @@
 title: Install Visual Studio Code
 sidebar:
   label: 3. Visual Studio Code
-  attrs:
-    class: windows
+  # attrs:
+  #   class: windows-wsl
 ---
 
 Visual Studio Code, also commonly known as *VS Code* or just *Code*, is a powerful and versatile code editor that enables efficient coding, debugging, and collaboration for your SplashKit projects!

--- a/src/content/docs/installation/Windows (WSL)/step-4.md
+++ b/src/content/docs/installation/Windows (WSL)/step-4.md
@@ -2,8 +2,8 @@
 title: Install Language Specific Tools
 sidebar:
   label: 4. Language Tools
-  attrs:
-    class: windows
+  # attrs:
+  #   class: windows
 ---
 
 ## Steps

--- a/src/styles/background.css
+++ b/src/styles/background.css
@@ -1,31 +1,28 @@
 /* Added a light theme gradient background with an animation for smooth transitions between colors. */
-:root[data-theme="light"] body {
+/* :root[data-theme="light"] body {
     width: 100%;
     height: 100%;
     background-color: #fff4e6;
-    /* background: linear-gradient(270deg, #fff9f4, #f5feff);
+    background: linear-gradient(270deg, #fff9f4, #f5feff);
     background-size: 800% 800%;
-    animation: gradient 10s ease infinite; */
+    animation: gradient 10s ease infinite;
     height: 100vh;
-}
- 
-:root[data-theme="dark"] body {
+} */
+
+/* Created a dark theme gradient background, with subtle transitions to enhance visual appeal. */
+/* :root[data-theme="dark"] body {
     width: 100%;
     height: 100%;
-<<<<<<< HEAD
     background: linear-gradient(270deg, #29211b, #161d21);
     background-size: 800% 800%;
     animation: gradient 10s ease infinite;
-=======
     background-color: #2c2118;
-    /* background: linear-gradient(270deg, #2c2118, #222e31); */
-    /* background-size: 800% 800%; */
-    /* animation: gradient 10s ease infinite; */
->>>>>>> 1c10996 (Minor changes in styling)
+    background: linear-gradient(270deg, #2c2118, #222e31); 
+    background-size: 800% 800%;
+    animation: gradient 10s ease infinite;
     height: 100vh;
-}
-/* Created a dark theme gradient background, with subtle transitions to enhance visual appeal. */
- 
+} */
+
 /* @keyframes gradient {
     0% {
         background-position: 0% 50%;
@@ -38,5 +35,4 @@
     100% {
         background-position: 0% 50%;
     }
-}
-  */
+} */

--- a/src/styles/background.css
+++ b/src/styles/background.css
@@ -11,7 +11,7 @@
 :root[data-theme="dark"] body {
     width: 100%;
     height: 100%;
-    background: linear-gradient(270deg, #2c2118, #222e31);
+    background: linear-gradient(270deg, #29211b, #161d21);
     background-size: 800% 800%;
     animation: gradient 10s ease infinite;
     height: 100vh;

--- a/src/styles/background.css
+++ b/src/styles/background.css
@@ -2,23 +2,31 @@
 :root[data-theme="light"] body {
     width: 100%;
     height: 100%;
-    background: linear-gradient(270deg, #fff9f4, #f5feff);
+    background-color: #fff4e6;
+    /* background: linear-gradient(270deg, #fff9f4, #f5feff);
     background-size: 800% 800%;
-    animation: gradient 10s ease infinite;
+    animation: gradient 10s ease infinite; */
     height: 100vh;
 }
  
 :root[data-theme="dark"] body {
     width: 100%;
     height: 100%;
+<<<<<<< HEAD
     background: linear-gradient(270deg, #29211b, #161d21);
     background-size: 800% 800%;
     animation: gradient 10s ease infinite;
+=======
+    background-color: #2c2118;
+    /* background: linear-gradient(270deg, #2c2118, #222e31); */
+    /* background-size: 800% 800%; */
+    /* animation: gradient 10s ease infinite; */
+>>>>>>> 1c10996 (Minor changes in styling)
     height: 100vh;
 }
 /* Created a dark theme gradient background, with subtle transitions to enhance visual appeal. */
  
-@keyframes gradient {
+/* @keyframes gradient {
     0% {
         background-position: 0% 50%;
     }
@@ -31,4 +39,4 @@
         background-position: 0% 50%;
     }
 }
- 
+  */

--- a/src/styles/background.css
+++ b/src/styles/background.css
@@ -1,20 +1,34 @@
-/* for animation background */
- /* body {
-     background: linear-gradient(-45deg, #ee7752, #f471a3, #23a6d5, #23d5ab);
-     background-size: 400% 400%;
-     animation: gradient 15s ease infinite;
-     height: 100vh;
- }
+/* Added a light theme gradient background with an animation for smooth transitions between colors. */
+:root[data-theme="light"] body {
+    width: 100%;
+    height: 100%;
+    background: linear-gradient(270deg, #fff9f4, #f5feff);
+    background-size: 800% 800%;
+    animation: gradient 10s ease infinite;
+    height: 100vh;
+}
  
- @keyframes gradient {
-     0% {
-         background-position: 0% 50%;
-     }
-     50% {
-         background-position: 100% 50%;
-     }
-     100% {
-         background-position: 0% 50%;
-     }
- } */
+:root[data-theme="dark"] body {
+    width: 100%;
+    height: 100%;
+    background: linear-gradient(270deg, #2c2118, #222e31);
+    background-size: 800% 800%;
+    animation: gradient 10s ease infinite;
+    height: 100vh;
+}
+/* Created a dark theme gradient background, with subtle transitions to enhance visual appeal. */
+ 
+@keyframes gradient {
+    0% {
+        background-position: 0% 50%;
+    }
+ 
+    50% {
+        background-position: 100% 50%;
+    }
+ 
+    100% {
+        background-position: 0% 50%;
+    }
+}
  

--- a/src/styles/cards.css
+++ b/src/styles/cards.css
@@ -1,57 +1,48 @@
-/* Defined new variables for card background and hover text colors, ensuring a consistent color scheme across different themes. */
+/* Variables for card background and hover text colors from splashkit logo. */
 :root {
   --sl-card-background-light: #fafafa;
   --sl-card-background-dark: #333333;
   --sl-hover-text-light: #ffffff;
   --sl-hover-text-dark: #000000;
-  /* Approximate orange from the logo */
   --sl-logo-orange: #F5A623;
-  --sl-logo-orange-dark: #ae7314;
-  /* Approximate blue from the text */
-  --sl-logo-blue: #4CA9BE;
-  --sl-logo-dark-blue: #3F51B5;
-  --gradient-light: rgba(232, 232, 234, 0.212);
-  --gradient-dark: rgba(23, 10, 10, 0.25);
+  --sl-logo-orange-dark: #b87501;
+  --sl-logo-blue: #05acc1;
+  --sl-logo-dark-blue: #3E50B1;
+  --gradient-light: rgba(232, 232, 234, 0.18);
+  --gradient-dark: rgba(23, 10, 10, 0.18);
 }
 
-/* Updated card styling for the light theme, including smooth transitions for background and text colors. */
-:root[data-theme="light"] .card {
+/* Card styling for the light and dark themes, including smooth transitions for background and text colors. */
+[data-theme="light"] .card {
   background: var(--sl-card-background-light);
   color: var(--sl-hover-text-dark);
   transition: transform 0.3s ease, background-color 0.3s ease, color 0.3s ease;
   width: 95%;
 }
-
-/* Applied a hover effect that changes background color, text color, and slightly scales the card up for a dynamic feel in the light theme. */
-:root[data-theme="light"] .card:hover {
-  background-color: var(--sl-logo-orange);
-  /* Updated to logo orange */
-  color: var(--sl-hover-text-light);
-  transform: scale(1.05);
-  box-shadow: 0px 4px 15px rgba(0, 0, 0, 0.2);
-  border: 1px solid var(--sl-logo-blue);
-  /* Border color added for hover */
-}
-
-/* Customized the card appearance for dark theme, maintaining consistency with light theme adjustments. */
-:root[data-theme="dark"] .card {
+[data-theme="dark"] .card {
   background: var(--sl-card-background-dark);
   color: var(--sl-hover-text-light);
   transition: transform 0.3s ease, background-color 0.3s ease, color 0.3s ease;
   width: 90%;
 }
 
-/* Enhanced dark theme cards with a similar hover effect as in the light theme, promoting uniformity. */
-:root[data-theme="dark"] .card:hover {
-  background-color: var(--sl-logo-dark-blue);
-  /* Updated to logo blue */
+/* Card hover effect in the light and dark themes. */
+[data-theme="light"] .card:hover {
+  background-color: var(--sl-logo-orange);
   color: var(--sl-hover-text-dark);
   transform: scale(1.05);
   box-shadow: 0px 4px 15px rgba(0, 0, 0, 0.2);
-  border: 2px solid var(--sl-logo-dark-blue);
-  /* Border color added for hover */
+  border: 1px solid var(--sl-logo-blue);
+}
+[data-theme="dark"] .card:hover {
+  background-color: var(--sl-logo-dark-blue);
+  color: var(--sl-hover-text-light);
+  transform: scale(1.05);
+  box-shadow: 0px 4px 15px rgba(0, 0, 0, 0.2);
+  border: 1px solid var(--sl-logo-blue);
 }
 
+/* Radial gradient following mouse */
 .card::before {
   content: "";
   position: absolute;
@@ -62,49 +53,77 @@
   background: radial-gradient(800px circle at var(--mouse-x) var(--mouse-y),
       var(--gradient-light),
       transparent 40%);
-  opacity: 0;
   /* Default to 0 to make it visible only on hover */
+  opacity: 0;
   z-index: 2;
   pointer-events: none;
 }
-
-:root[data-theme="dark"] .card::before {
+[data-theme="dark"] .card::before {
   background: radial-gradient(800px circle at var(--mouse-x) var(--mouse-y),
       var(--gradient-dark),
       transparent 40%);
 }
-
 .card:hover::before {
   opacity: 1;
 }
 
-/* Link card styling */
-:root[data-theme="light"] .sl-link-card:hover {
-  background-color: var(--sl-logo-orange);
-  
-  .description {
-    color: var(--sl-hover-text-light);
-  }
+
+/* Link card border */
+[data-theme="light"] .sl-link-card {
+  border: 1px solid var(--sl-logo-blue);
+}
+[data-theme="dark"] .sl-link-card {
+  border: 1px solid var(--sl-logo-orange);
 }
 
-:root[data-theme="dark"] .sl-link-card:hover {
-  background-color: var(--sl-logo-dark-blue);
-  transition: transform 0.3s ease, background-color 0.3s ease, color 0.3s ease;
+/* Link card hover effects */
+[data-theme="light"] .sl-link-card:hover {
+  background-color: var(--sl-logo-orange);
   .description {
     color: var(--sl-hover-text-dark);
   }
 }
-
-/* Link card inside card */
-:root[data-theme="light"] .card:hover .sl-link-card:hover {
-  background-color: var(--sl-logo-blue);
+[data-theme="dark"] .sl-link-card:hover {
+  background-color: var(--sl-logo-dark-blue);
+  border: 1px solid var(--sl-logo-blue);
   .description {
     color: var(--sl-hover-text-light);
   }
 }
-:root[data-theme="dark"] .card:hover .sl-link-card:hover {
-  background-color: var(--sl-logo-orange-dark);
+
+/* Link card when card hovered over */
+[data-theme="light"] .card:hover .sl-link-card {
+  border: 1px solid var(--sl-logo-dark-blue);
   .description {
+    color: var(--sl-hover-text-dark);
+  }
+}
+[data-theme="dark"] .card:hover .sl-link-card {
+  .description {
+    color: var(--sl-hover-text-dark);
+  }
+  .astro-mf7fz2mj {
+    color: var(--sl-hover-text-light);
+  }
+}
+
+/* Link card hover effects inside card*/
+[data-theme="light"] .card .sl-link-card:hover {
+  background-color: var(--sl-logo-dark-blue);
+  border: 1px solid var(--sl-logo-blue);
+  .description {
+    color: var(--sl-hover-text-light);
+  }
+  .astro-mf7fz2mj {
+    color: var(--sl-hover-text-light);
+  }
+}
+[data-theme="dark"] .card .sl-link-card:hover {
+  background-color: var(--sl-logo-orange);
+  .description {
+    color: var(--sl-hover-text-dark);
+  }
+  .astro-mf7fz2mj {
     color: var(--sl-hover-text-dark);
   }
 }

--- a/src/styles/cards.css
+++ b/src/styles/cards.css
@@ -1,35 +1,84 @@
- .card {
-  border-radius: 12px;
-  position: relative;
-  background: radial-gradient(
-      300px circle at top left,
-      rgba(85, 44, 190, 0.081) 20%,
-      transparent 100%
-    ),
-    radial-gradient(
-      300px circle at bottom right,
-      rgba(44, 102, 190, 0.09) 20%,
-      transparent 100%
-    );
+:root {
+  --sl-card-background-light: #fafafa;
+  --sl-card-background-dark: #333333;
+  --sl-hover-text-light: #ffffff;
+  --sl-hover-text-dark: #000000;
+  --sl-logo-orange: #f7941d;
+  /* Approximate orange from the logo */
+  --sl-logo-blue: #126ca8;
+  /* Approximate blue from the text */
+  --gradient-light: rgba(232, 232, 234, 0.212);
+  --gradient-dark: rgba(23, 10, 10, 0.25);
+}
+/* Defined new variables for card background and hover text colors, ensuring a consistent color scheme across different themes. */
+
+:root[data-theme="light"] .card {
+  background: var(--sl-card-background-light);
+  color: var(--sl-hover-text-dark);
+  transition: transform 0.3s ease, background-color 0.3s ease, color 0.3s ease;
+  width: 95%;
 }
 
- .card::before {
+/* Updated card styling for the light theme, including smooth transitions for background and text colors. */
+
+:root[data-theme="light"] .card:hover {
+  background-color: var(--sl-logo-orange);
+  /* Updated to logo orange */
+  color: var(--sl-hover-text-light);
+  transform: scale(1.05);
+  box-shadow: 0px 4px 15px rgba(0, 0, 0, 0.2);
+  border: 1px solid var(--sl-logo-blue);
+  /* Border color added for hover */
+}
+
+/* Applied a hover effect that changes background color, text color, and slightly scales the card up for a dynamic feel in the light theme. */
+
+:root[data-theme="dark"] .card {
+  background: var(--sl-card-background-dark);
+  color: var(--sl-hover-text-light);
+  transition: transform 0.3s ease, background-color 0.3s ease, color 0.3s ease;
+  width: 90%;
+}
+
+/* Customized the card appearance for dark theme, maintaining consistency with light theme adjustments. */
+
+:root[data-theme="dark"] .card:hover {
+  background-color: var(--sl-logo-blue);
+  /* Updated to logo blue */
+  color: var(--sl-hover-text-dark);
+  transform: scale(1.05);
+  box-shadow: 0px 4px 15px rgba(0, 0, 0, 0.2);
+  border: 2px solid var(--sl-logo-blue);
+  /* Border color added for hover */
+}
+
+/* Enhanced dark theme cards with a similar hover effect as in the light theme, promoting uniformity. */
+
+.card::before {
   content: "";
   position: absolute;
   inset: 0px;
   border-radius: inherit;
   transition: opacity 400ms ease 0s;
   will-change: background, opacity;
-  background: radial-gradient(
-    800px circle at var(--mouse-x) var(--mouse-y),
-    rgba(62, 85, 167, 0.212),
-    transparent 40%
-  );
+  background: radial-gradient(800px circle at var(--mouse-x) var(--mouse-y),
+      var(--gradient-light),
+      transparent 40%);
   opacity: 0;
+  /* Default to 0 to make it visible only on hover */
   z-index: 2;
   pointer-events: none;
+}
+
+
+:root[data-theme="dark"] .card::before {
+  background: radial-gradient(800px circle at var(--mouse-x) var(--mouse-y),
+      var(--gradient-dark),
+      transparent 40%);
 }
 
 .card:hover::before {
   opacity: 1;
 }
+
+/* I have added a border to my card which matches with the blue color in the SplashKit's logo, and made a light gradient to follow the cursor in light mode and vice versa*/

--- a/src/styles/cards.css
+++ b/src/styles/cards.css
@@ -1,48 +1,59 @@
-/* Variables for card background and hover text colors from splashkit logo. */
 :root {
   --sl-card-background-light: #fafafa;
   --sl-card-background-dark: #333333;
   --sl-hover-text-light: #ffffff;
   --sl-hover-text-dark: #000000;
-  --sl-logo-orange: #F5A623;
-  --sl-logo-orange-dark: #b87501;
-  --sl-logo-blue: #05acc1;
-  --sl-logo-dark-blue: #3E50B1;
-  --gradient-light: rgba(232, 232, 234, 0.18);
-  --gradient-dark: rgba(23, 10, 10, 0.18);
+  --sl-logo-orange: #f7941d;
+  /* Approximate orange from the logo */
+  --sl-logo-blue: #126ca8;
+  /* Approximate blue from the text */
+  --gradient-light: rgba(232, 232, 234, 0.212);
+  --gradient-dark: rgba(23, 10, 10, 0.25);
 }
+/* Defined new variables for card background and hover text colors, ensuring a consistent color scheme across different themes. */
 
-/* Card styling for the light and dark themes, including smooth transitions for background and text colors. */
-[data-theme="light"] .card {
+:root[data-theme="light"] .card {
   background: var(--sl-card-background-light);
   color: var(--sl-hover-text-dark);
   transition: transform 0.3s ease, background-color 0.3s ease, color 0.3s ease;
   width: 95%;
 }
-[data-theme="dark"] .card {
+
+/* Updated card styling for the light theme, including smooth transitions for background and text colors. */
+
+:root[data-theme="light"] .card:hover {
+  background-color: var(--sl-logo-orange);
+  /* Updated to logo orange */
+  color: var(--sl-hover-text-light);
+  /* transform: scale(1.05); */
+  box-shadow: 0px 4px 15px rgba(0, 0, 0, 0.2);
+  border: 1px solid var(--sl-logo-blue);
+  /* Border color added for hover */
+}
+
+/* Applied a hover effect that changes background color, text color, and slightly scales the card up for a dynamic feel in the light theme. */
+
+:root[data-theme="dark"] .card {
   background: var(--sl-card-background-dark);
   color: var(--sl-hover-text-light);
   transition: transform 0.3s ease, background-color 0.3s ease, color 0.3s ease;
   width: 90%;
 }
 
-/* Card hover effect in the light and dark themes. */
-[data-theme="light"] .card:hover {
-  background-color: var(--sl-logo-orange);
+/* Customized the card appearance for dark theme, maintaining consistency with light theme adjustments. */
+
+:root[data-theme="dark"] .card:hover {
+  background-color: var(--sl-logo-blue);
+  /* Updated to logo blue */
   color: var(--sl-hover-text-dark);
-  transform: scale(1.05);
+  /* transform: scale(1.05); */
   box-shadow: 0px 4px 15px rgba(0, 0, 0, 0.2);
-  border: 1px solid var(--sl-logo-blue);
-}
-[data-theme="dark"] .card:hover {
-  background-color: var(--sl-logo-dark-blue);
-  color: var(--sl-hover-text-light);
-  transform: scale(1.05);
-  box-shadow: 0px 4px 15px rgba(0, 0, 0, 0.2);
-  border: 1px solid var(--sl-logo-blue);
+  border: 2px solid var(--sl-logo-blue);
+  /* Border color added for hover */
 }
 
-/* Radial gradient following mouse */
+/* Enhanced dark theme cards with a similar hover effect as in the light theme, promoting uniformity. */
+
 .card::before {
   content: "";
   position: absolute;
@@ -53,78 +64,21 @@
   background: radial-gradient(800px circle at var(--mouse-x) var(--mouse-y),
       var(--gradient-light),
       transparent 40%);
-  /* Default to 0 to make it visible only on hover */
   opacity: 0;
+  /* Default to 0 to make it visible only on hover */
   z-index: 2;
   pointer-events: none;
 }
-[data-theme="dark"] .card::before {
+
+
+:root[data-theme="dark"] .card::before {
   background: radial-gradient(800px circle at var(--mouse-x) var(--mouse-y),
       var(--gradient-dark),
       transparent 40%);
 }
+
 .card:hover::before {
   opacity: 1;
 }
 
-
-/* Link card border */
-[data-theme="light"] .sl-link-card {
-  border: 1px solid var(--sl-logo-blue);
-}
-[data-theme="dark"] .sl-link-card {
-  border: 1px solid var(--sl-logo-orange);
-}
-
-/* Link card hover effects */
-[data-theme="light"] .sl-link-card:hover {
-  background-color: var(--sl-logo-orange);
-  border: 1px solid var(--sl-logo-blue);
-  .description {
-    color: var(--sl-hover-text-dark);
-  }
-}
-[data-theme="dark"] .sl-link-card:hover {
-  background-color: var(--sl-logo-dark-blue);
-  border: 1px solid var(--sl-logo-blue);
-  .description {
-    color: var(--sl-hover-text-light);
-  }
-}
-
-/* Link card when card hovered over */
-[data-theme="light"] .card:hover .sl-link-card {
-  border: 1px solid var(--sl-logo-dark-blue);
-  .description {
-    color: var(--sl-hover-text-dark);
-  }
-}
-[data-theme="dark"] .card:hover .sl-link-card {
-  .description {
-    color: var(--sl-hover-text-dark);
-  }
-  .astro-mf7fz2mj {
-    color: var(--sl-hover-text-light);
-  }
-}
-
-/* Link card hover effects inside card*/
-[data-theme="light"] .card .sl-link-card:hover {
-  background-color: var(--sl-logo-dark-blue);
-  border: 1px solid var(--sl-logo-blue);
-  .description {
-    color: var(--sl-hover-text-light);
-  }
-  .astro-mf7fz2mj {
-    color: var(--sl-hover-text-light);
-  }
-}
-[data-theme="dark"] .card .sl-link-card:hover {
-  background-color: var(--sl-logo-orange);
-  .description {
-    color: var(--sl-hover-text-dark);
-  }
-  .astro-mf7fz2mj {
-    color: var(--sl-hover-text-dark);
-  }
-}
+/* I have added a border to my card which matches with the blue color in the SplashKit's logo, and made a light gradient to follow the cursor in light mode and vice versa*/

--- a/src/styles/cards.css
+++ b/src/styles/cards.css
@@ -1,17 +1,20 @@
+/* Defined new variables for card background and hover text colors, ensuring a consistent color scheme across different themes. */
 :root {
   --sl-card-background-light: #fafafa;
   --sl-card-background-dark: #333333;
   --sl-hover-text-light: #ffffff;
   --sl-hover-text-dark: #000000;
-  --sl-logo-orange: #f7941d;
   /* Approximate orange from the logo */
-  --sl-logo-blue: #126ca8;
+  --sl-logo-orange: #F5A623;
+  --sl-logo-orange-dark: #ae7314;
   /* Approximate blue from the text */
+  --sl-logo-blue: #4CA9BE;
+  --sl-logo-dark-blue: #3F51B5;
   --gradient-light: rgba(232, 232, 234, 0.212);
   --gradient-dark: rgba(23, 10, 10, 0.25);
 }
-/* Defined new variables for card background and hover text colors, ensuring a consistent color scheme across different themes. */
 
+/* Updated card styling for the light theme, including smooth transitions for background and text colors. */
 :root[data-theme="light"] .card {
   background: var(--sl-card-background-light);
   color: var(--sl-hover-text-dark);
@@ -19,8 +22,7 @@
   width: 95%;
 }
 
-/* Updated card styling for the light theme, including smooth transitions for background and text colors. */
-
+/* Applied a hover effect that changes background color, text color, and slightly scales the card up for a dynamic feel in the light theme. */
 :root[data-theme="light"] .card:hover {
   background-color: var(--sl-logo-orange);
   /* Updated to logo orange */
@@ -31,8 +33,7 @@
   /* Border color added for hover */
 }
 
-/* Applied a hover effect that changes background color, text color, and slightly scales the card up for a dynamic feel in the light theme. */
-
+/* Customized the card appearance for dark theme, maintaining consistency with light theme adjustments. */
 :root[data-theme="dark"] .card {
   background: var(--sl-card-background-dark);
   color: var(--sl-hover-text-light);
@@ -40,19 +41,16 @@
   width: 90%;
 }
 
-/* Customized the card appearance for dark theme, maintaining consistency with light theme adjustments. */
-
+/* Enhanced dark theme cards with a similar hover effect as in the light theme, promoting uniformity. */
 :root[data-theme="dark"] .card:hover {
-  background-color: var(--sl-logo-blue);
+  background-color: var(--sl-logo-dark-blue);
   /* Updated to logo blue */
   color: var(--sl-hover-text-dark);
   transform: scale(1.05);
   box-shadow: 0px 4px 15px rgba(0, 0, 0, 0.2);
-  border: 2px solid var(--sl-logo-blue);
+  border: 2px solid var(--sl-logo-dark-blue);
   /* Border color added for hover */
 }
-
-/* Enhanced dark theme cards with a similar hover effect as in the light theme, promoting uniformity. */
 
 .card::before {
   content: "";
@@ -70,7 +68,6 @@
   pointer-events: none;
 }
 
-
 :root[data-theme="dark"] .card::before {
   background: radial-gradient(800px circle at var(--mouse-x) var(--mouse-y),
       var(--gradient-dark),
@@ -81,4 +78,33 @@
   opacity: 1;
 }
 
-/* I have added a border to my card which matches with the blue color in the SplashKit's logo, and made a light gradient to follow the cursor in light mode and vice versa*/
+/* Link card styling */
+:root[data-theme="light"] .sl-link-card:hover {
+  background-color: var(--sl-logo-orange);
+  
+  .description {
+    color: var(--sl-hover-text-light);
+  }
+}
+
+:root[data-theme="dark"] .sl-link-card:hover {
+  background-color: var(--sl-logo-dark-blue);
+  transition: transform 0.3s ease, background-color 0.3s ease, color 0.3s ease;
+  .description {
+    color: var(--sl-hover-text-dark);
+  }
+}
+
+/* Link card inside card */
+:root[data-theme="light"] .card:hover .sl-link-card:hover {
+  background-color: var(--sl-logo-blue);
+  .description {
+    color: var(--sl-hover-text-light);
+  }
+}
+:root[data-theme="dark"] .card:hover .sl-link-card:hover {
+  background-color: var(--sl-logo-orange-dark);
+  .description {
+    color: var(--sl-hover-text-dark);
+  }
+}

--- a/src/styles/cards.css
+++ b/src/styles/cards.css
@@ -80,7 +80,7 @@
 [data-theme="light"] .sl-link-card {
   background: var(--sl-card-background-light);
   border: 1px solid var(--sl-logo-blue);
-  box-shadow: 0px 0px 10px var(--sl-logo-blue);
+  box-shadow: 0px 0px 5px var(--sl-logo-blue);
   margin: 5px;
 
   .description {
@@ -91,7 +91,7 @@
 [data-theme="dark"] .sl-link-card {
   background: var(--sl-card-background-dark);
   border: 1px solid var(--sl-logo-orange);
-  box-shadow: 0px 0px 10px var(--sl-logo-orange);
+  box-shadow: 0px 0px 5px var(--sl-logo-orange);
   margin: 5px;
 
   .description {
@@ -103,7 +103,7 @@
 [data-theme="light"] .sl-link-card:hover {
   background: var(--sl-card-background-light);
   border: 1px solid var(--sl-logo-orange);
-  box-shadow: 0px 0px 20px var(--sl-logo-orange);
+  box-shadow: 0px 0px 15px var(--sl-logo-orange);
 
   .description {
     color: var(--sl-hover-text-dark);
@@ -113,7 +113,7 @@
 [data-theme="dark"] .sl-link-card:hover {
   background: var(--sl-card-background-dark);
   border: 1px solid var(--sl-logo-blue);
-  box-shadow: 0px 0px 20px var(--sl-logo-blue);
+  box-shadow: 0px 0px 15px var(--sl-logo-blue);
 
   .description {
     color: var(--sl-hover-text-light);

--- a/src/styles/cards.css
+++ b/src/styles/cards.css
@@ -79,6 +79,7 @@
 /* Link card hover effects */
 [data-theme="light"] .sl-link-card:hover {
   background-color: var(--sl-logo-orange);
+  border: 1px solid var(--sl-logo-blue);
   .description {
     color: var(--sl-hover-text-dark);
   }

--- a/src/styles/cards.css
+++ b/src/styles/cards.css
@@ -1,60 +1,55 @@
+/* Variables for card background and hover text colors from splashkit logo. */
 :root {
-  --sl-card-background-light: #fafafa;
+  --sl-card-background-light: #f8f8f8;
   --sl-card-background-dark: #333333;
   --sl-hover-text-light: #ffffff;
   --sl-hover-text-dark: #000000;
-  --sl-logo-orange: #f7941d;
-  /* Approximate orange from the logo */
-  --sl-logo-blue: #126ca8;
-  /* Approximate blue from the text */
-  --gradient-light: rgba(232, 232, 234, 0.212);
-  --gradient-dark: rgba(23, 10, 10, 0.25);
+  --sl-logo-orange: #F5A623;
+  --sl-logo-blue: #05acc1;
+  --sl-logo-dark-blue: #3E50B1;
+  --gradient-light: rgba(232, 232, 234, 0.18);
+  --gradient-dark: rgba(23, 10, 10, 0.18);
 }
-/* Defined new variables for card background and hover text colors, ensuring a consistent color scheme across different themes. */
 
-:root[data-theme="light"] .card {
+/* --- START: Card styling ------*/
+
+/* Card styling for the light and dark themes, including smooth transitions for background and text colors. */
+[data-theme="light"] .card {
+  background: var(--sl-color-gray-6);
   background: var(--sl-card-background-light);
   color: var(--sl-hover-text-dark);
   transition: transform 0.3s ease, background-color 0.3s ease, color 0.3s ease;
+  border: 1px solid var(--sl-logo-dark-blue);
   width: 95%;
 }
 
-/* Updated card styling for the light theme, including smooth transitions for background and text colors. */
-
-:root[data-theme="light"] .card:hover {
-  background-color: var(--sl-logo-orange);
-  /* Updated to logo orange */
-  color: var(--sl-hover-text-light);
-  /* transform: scale(1.05); */
-  box-shadow: 0px 4px 15px rgba(0, 0, 0, 0.2);
-  border: 1px solid var(--sl-logo-blue);
-  /* Border color added for hover */
-}
-
-/* Applied a hover effect that changes background color, text color, and slightly scales the card up for a dynamic feel in the light theme. */
-
-:root[data-theme="dark"] .card {
+[data-theme="dark"] .card {
   background: var(--sl-card-background-dark);
   color: var(--sl-hover-text-light);
   transition: transform 0.3s ease, background-color 0.3s ease, color 0.3s ease;
-  width: 90%;
+  border: 1px solid var(--sl-logo-dark-blue);
+  width: 95%;
 }
 
-/* Customized the card appearance for dark theme, maintaining consistency with light theme adjustments. */
+/* Will add parts below back in when button toggle for animations added */
 
-:root[data-theme="dark"] .card:hover {
-  background-color: var(--sl-logo-blue);
-  /* Updated to logo blue */
+/* Card hover effect in the light and dark themes. */
+/* [data-theme="light"] .card:hover {
+  background-color: var(--sl-logo-orange);
   color: var(--sl-hover-text-dark);
-  /* transform: scale(1.05); */
+  transform: scale(1.05);
   box-shadow: 0px 4px 15px rgba(0, 0, 0, 0.2);
-  border: 2px solid var(--sl-logo-blue);
-  /* Border color added for hover */
 }
 
-/* Enhanced dark theme cards with a similar hover effect as in the light theme, promoting uniformity. */
+[data-theme="dark"] .card:hover {
+  background-color: var(--sl-logo-dark-blue);
+  color: var(--sl-hover-text-light);
+  transform: scale(1.05);
+  box-shadow: 0px 4px 15px rgba(0, 0, 0, 0.2);
+} */
 
-.card::before {
+/* Radial gradient following mouse */
+/* .card::before {
   content: "";
   position: absolute;
   inset: 0px;
@@ -65,13 +60,11 @@
       var(--gradient-light),
       transparent 40%);
   opacity: 0;
-  /* Default to 0 to make it visible only on hover */
   z-index: 2;
   pointer-events: none;
 }
 
-
-:root[data-theme="dark"] .card::before {
+[data-theme="dark"] .card::before {
   background: radial-gradient(800px circle at var(--mouse-x) var(--mouse-y),
       var(--gradient-dark),
       transparent 40%);
@@ -79,6 +72,52 @@
 
 .card:hover::before {
   opacity: 1;
+} */
+
+/* --- END: Card styling ------*/
+
+/* --- START: Link card styling ------*/
+[data-theme="light"] .sl-link-card {
+  background: var(--sl-card-background-light);
+  border: 1px solid var(--sl-logo-blue);
+  box-shadow: 0px 0px 10px var(--sl-logo-blue);
+  margin: 5px;
+
+  .description {
+    color: var(--sl-hover-text-dark);
+  }
 }
 
-/* I have added a border to my card which matches with the blue color in the SplashKit's logo, and made a light gradient to follow the cursor in light mode and vice versa*/
+[data-theme="dark"] .sl-link-card {
+  background: var(--sl-card-background-dark);
+  border: 1px solid var(--sl-logo-orange);
+  box-shadow: 0px 0px 10px var(--sl-logo-orange);
+  margin: 5px;
+
+  .description {
+    color: var(--sl-hover-text-light);
+  }
+}
+
+/* Hover effects */
+[data-theme="light"] .sl-link-card:hover {
+  background: var(--sl-card-background-light);
+  border: 1px solid var(--sl-logo-orange);
+  box-shadow: 0px 0px 20px var(--sl-logo-orange);
+
+  .description {
+    color: var(--sl-hover-text-dark);
+  }
+}
+
+[data-theme="dark"] .sl-link-card:hover {
+  background: var(--sl-card-background-dark);
+  border: 1px solid var(--sl-logo-blue);
+  box-shadow: 0px 0px 20px var(--sl-logo-blue);
+
+  .description {
+    color: var(--sl-hover-text-light);
+  }
+}
+
+/* --- END: Link card styling ------*/

--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -13,7 +13,7 @@
 
 /* Light mode colors. */
 :root[data-theme='light'] {
-/*   --sl-color-accent: #00A9E0; */
+  /*   --sl-color-accent: #00A9E0; */
   --sl-color-accent: #3D50f5;
 }
 
@@ -52,7 +52,7 @@ iframe[id="stackblitz-iframe"] {
   transition: background-color ease-in-out 0.25s, color 0.3s ease;
   position: relative;
   overflow: hidden;
-/*   background-color: white;
+  /*   background-color: white;
   color: black; */
   cursor: pointer;
 }
@@ -83,26 +83,17 @@ iframe[id="stackblitz-iframe"] {
 }
 
 @keyframes moveGradient {
-  0% { background-position: 0% 50%; }
-  50% { background-position: 100% 50%; }
-  100% { background-position: 0% 50%; }
-  z-index: -1;
-}
+  0% {
+    background-position: 0% 50%;
+  }
 
-[data-has-hero] .hero .action:hover::before {
-  opacity: 1;
-  animation: moveGradient 3s linear infinite;
-}
+  50% {
+    background-position: 100% 50%;
+  }
 
-[data-has-hero] .hero .action:hover {
-  color: white;
-  background-color: transparent;
-}
-
-@keyframes moveGradient {
-  0% { background-position: 0% 50%; }
-  50% { background-position: 100% 50%; }
-  100% { background-position: 0% 50%; }
+  100% {
+    background-position: 0% 50%;
+  }
 }
 
 [data-has-hero] .hero .action.minimal {
@@ -151,39 +142,62 @@ img {
   font-display: swap;
 }
 
-/* Additional styles for the site and icons */
-
-/* Additional styles for the site and icons */
 .home-card {
   border-radius: 20%;
   border: 1px dotted black;
 }
 
-html[data-theme="dark"] a.multitool:after,
-html[data-theme="dark"] a.apple:after,
-html[data-theme="dark"] a.windows:after,
-
-html[data-theme="dark"] a.multitool:after,
-html[data-theme="dark"] a.apple:after,
-html[data-theme="dark"] a.windows:after,
-html[data-theme="dark"] a.linux:after {
-  border: 1px solid black;
-}
-
-a.pi:after,
-a.apple:after,
-a.windows:after,
-a.pi:after,
-a.apple:after,
-a.windows:after,
-a.linux:after {
+a.pi:after {
   font-family: "FontAwesomeBrands";
-  content: "\f7bb"; /* example, adjust the content value for each specific icon */
-  content: "\f7bb"; /* example, adjust the content value for each specific icon */
+  content: "\f7bb";
   float: right;
   border-radius: 5px;
   border: 1px solid white;
   padding: 0px 5px 0px 5px;
+}
+
+a.apple:after {
+  font-family: "FontAwesomeBrands";
+  content: "\f179";
+  float: right;
+  border-radius: 5px;
+  border: 1px solid white;
+  padding: 0px 5px 0px 5px;
+}
+
+a.windows:after {
+  font-family: "FontAwesomeBrands";
+  content: "\f17a";
+  float: right;
+  border-radius: 5px;
+  border: 1px solid white;
+  padding: 0px 5px 0px 5px;
+
+}
+
+a.windows-wsl:after {
+  font-family: "FontAwesomeBrands";
+  content: "\f17a  \f17c";
+  float: right;
+  border-radius: 5px;
+  border: 1px solid white;
+  padding: 0px 5px 0px 5px;
+}
+
+a.linux:after {
+  font-family: "FontAwesomeBrands";
+  content: "\f17c";
+  float: right;
+  border-radius: 5px;
+  border: 1px solid white;
+  padding: 0px 5px 0px 5px;
+}
+
+html[data-theme="dark"] a.apple:after,
+html[data-theme="dark"] a.windows:after,
+html[data-theme="dark"] a.windows-wsl:after,
+html[data-theme="dark"] a.linux:after {
+  border: 1px solid black;
 }
 
 /* XQuest changes */
@@ -289,4 +303,3 @@ code {
   transition: transform 0.3s ease;
   filter: drop-shadow(0 0 2rem var(--splashkit-blue));
 }
-/* Enhanced the hover effect on hero images by increasing the shadow size and applying a slight scale-up animation. */

--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -6,6 +6,7 @@
 :root {
   --purple-hsl: 255, 60%, 60%;
   --overlay-blurple: hsla(var(--purple-hsl), 0.2);
+  /* --table-head-color: rgb(35, 38, 47); */
 }
 
 /* Light mode colors. */
@@ -13,6 +14,15 @@
   --purple-hsl: 255, 85%, 65%;
   --sl-hue-accent: 350;
   --sl-color-accent: #3D50f5;
+
+  /* Potential colours to use when the site can toggle the theme in the future */
+  /* --table-head-color: rgb(244, 245, 247); */
+  /* --table-head-color: hsla(187, 99%, 38%, 0.35); light splashkit blue*/
+  /* --table-head-color: rgb(245, 166, 35);   splashkit orange */
+  /*--table-head-color: rgb(1, 172, 194);     splashkit blue*/
+  /* --table-head-color: rgb(201, 231, 240);	  light blue */
+  /*--table-head-color: rgb(255, 167, 126);   light orange*/
+  /*--table-head-color: rgb(245, 139, 90);	  dark orange*/
 }
 
 .hero img {
@@ -22,8 +32,10 @@
 }
 
 .hero img:hover {
-  transform: scale(1.1); /* Enlarge the image on hover */
-  transition: transform 0.3s ease; /* Add a smooth transition effect */
+  transform: scale(1.1);
+  /* Enlarge the image on hover */
+  transition: transform 0.3s ease;
+  /* Add a smooth transition effect */
 }
 
 [data-has-hero] .page {
@@ -38,7 +50,8 @@
   -webkit-backdrop-filter: blur(16px);
   backdrop-filter: blur(16px);
 }
-[data-has-hero] .hero > img {
+
+[data-has-hero] .hero>img {
   filter: drop-shadow(0 0 3rem var(--overlay-blurple));
 }
 
@@ -46,7 +59,8 @@ iframe[id="stackblitz-iframe"] {
   width: 100%;
   min-height: 600px;
 }
-[data-has-hero] .hero > div.sl-flex {
+
+[data-has-hero] .hero>div.sl-flex {
   align-self: flex-start;
 }
 
@@ -69,11 +83,9 @@ iframe[id="stackblitz-iframe"] {
 }
 
 [data-has-hero] .hero .hero-gradient-text {
-  background: radial-gradient(
-      circle at top left,
+  background: radial-gradient(circle at top left,
       hsl(296, 100%, 50%) 0%,
-      transparent 50%
-    ),
+      transparent 50%),
     radial-gradient(circle at center, rgb(113, 147, 233) 0%, transparent 100%),
     radial-gradient(circle at bottom right, rgb(0, 68, 255) 0%, transparent 50%);
   color: transparent;
@@ -91,16 +103,12 @@ img {
 [data-has-hero] .card {
   border-radius: 12px;
   position: relative;
-  background: radial-gradient(
-      300px circle at top left,
+  background: radial-gradient(300px circle at top left,
       rgba(85, 44, 190, 0.081) 20%,
-      transparent 100%
-    ),
-    radial-gradient(
-      300px circle at bottom right,
+      transparent 100%),
+    radial-gradient(300px circle at bottom right,
       rgba(44, 102, 190, 0.09) 20%,
-      transparent 100%
-    );
+      transparent 100%);
 }
 
 [data-has-hero] .card::before {
@@ -110,11 +118,9 @@ img {
   border-radius: inherit;
   transition: opacity 400ms ease 0s;
   will-change: background, opacity;
-  background: radial-gradient(
-    800px circle at var(--mouse-x) var(--mouse-y),
+  background: radial-gradient(800px circle at var(--mouse-x) var(--mouse-y),
       rgba(62, 85, 167, 0.212),
-    transparent 40%
-  );
+      transparent 40%);
   opacity: 0;
   z-index: 2;
   pointer-events: none;
@@ -143,10 +149,12 @@ img {
   font-style: normal;
   font-display: swap;
 }
+
 .home-card {
   border-radius: 20%;
   border: 1px dotted black;
 }
+
 html[data-theme="dark"] a.multitool:after {
   border: 1px solid black;
 }
@@ -241,28 +249,43 @@ a.decent:hover {
 .sl-markdown-content table {
   border-radius: 0.5rem;
   box-shadow: var(--sl-shadow-md);
-  border: 1px solid var(--sl-color-gray-6);
+  border: 1px solid var(--sl-color-gray-5);
   width: max-content;
   max-width: 100%;
+  text-align: left;
+}
+
+.sl-markdown-content table th {
+  border-right: 1px solid var(--sl-color-gray-5);
+}
+
+.sl-markdown-content table td {
+  border-right: 1px solid var(--sl-color-gray-5);
 }
 
 .sl-markdown-content table td:first-child,
 .sl-markdown-content table th:first-child {
   border-left: none;
+  padding-left: 15px;
 }
 
 .sl-markdown-content table td:last-child,
 .sl-markdown-content table th:last-child {
   border-right: none;
+  padding-right: 15px;
 }
 
 .sl-markdown-content table tr:first-child th {
   border-top: none;
+  text-align: left;
+  background-color: var(--sl-color-gray-6);
+  /* color: white; */
 }
 
 .sl-markdown-content table tr:last-child td {
   border-bottom: none;
 }
+
 .starlight-aside,
 .card {
   border-radius: 0.5rem;
@@ -271,6 +294,7 @@ a.decent:hover {
 code {
   border-radius: 0.25rem;
 }
+
 .expressive-code {
   border-radius: 0.6rem;
   box-shadow: var(--sl-shadow-md);

--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -17,6 +17,24 @@
   --sl-color-accent: #3D50f5;
 }
 
+.hero {
+  padding-top: 80px;
+  padding-bottom: 30px;
+}
+.hero img {
+  transition: transform 0.3s ease, filter 0.3s ease;
+  width: 90%;
+  height: 90%;
+  margin-top: -40px;
+  /* filter: drop-shadow(0 0 1rem var(--splashkit-blue)); */
+}
+
+.hero img:hover {
+  transform: scale(1.1);
+  transition: transform 0.3s ease;
+  /* filter: drop-shadow(0 0 2rem var(--splashkit-blue)); */
+}
+
 [data-has-hero] .page {
   background: linear-gradient(215deg, var(--overlay-blurple), transparent 40%),
     radial-gradient(var(--overlay-blurple), transparent 40%) no-repeat -60vw -40vh / 105vw 200vh,
@@ -30,7 +48,7 @@
   backdrop-filter: blur(16px);
 }
 
-[data-has-hero] .hero>img {
+[data-has-hero] .hero > img {
   filter: drop-shadow(0 0 3rem var(--overlay-blurple));
 }
 
@@ -39,7 +57,7 @@ iframe[id="stackblitz-iframe"] {
   min-height: 600px;
 }
 
-[data-has-hero] .hero>div.sl-flex {
+[data-has-hero] .hero > div.sl-flex {
   align-self: flex-start;
 }
 
@@ -287,19 +305,4 @@ code {
   vertical-align: middle;
   border: 1px solid lightgray;
   margin-left: 20px;
-}
-
-/* Applied a blue drop-shadow effect to hero images, enhancing their visibility and focus. */
-.hero img {
-  transition: transform 0.3s ease, filter 0.3s ease;
-  width: 90%;
-  height: 90%;
-  /* filter: drop-shadow(0 0 1rem var(--splashkit-blue)); */
-}
-
-/* Blue shadow background upon hover for the splashkit logo */
-.hero img:hover {
-  transform: scale(1.1);
-  transition: transform 0.3s ease;
-  /* filter: drop-shadow(0 0 2rem var(--splashkit-blue)); */
 }

--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -4,10 +4,12 @@
 
 /* Dark mode colors. */
 :root {
-  --splashkit-blue: #00A9E0;
-  --splashkit-blue: #00A9E0;
   --purple-hsl: 255, 60%, 60%;
   --overlay-blurple: hsla(var(--purple-hsl), 0.2);
+  --sk-logo-blue: #00ACC1;
+  --sk-logo-orange: #F5A623;
+  --link-button-border-color: var(--sk-logo-orange);
+  --link-hover-button-border-color: var(--sk-logo-blue);
   /* --table-head-color: rgb(35, 38, 47); */
 }
 
@@ -15,24 +17,27 @@
 :root[data-theme='light'] {
   /*   --sl-color-accent: #00A9E0; */
   --sl-color-accent: #3D50f5;
+  --link-button-border-color: var(--sk-logo-blue);
+  --link-hover-button-border-color: var(--sk-logo-orange);
 }
 
 .hero {
   padding-top: 80px;
   padding-bottom: 30px;
 }
+
 .hero img {
   transition: transform 0.3s ease, filter 0.3s ease;
   width: 90%;
   height: 90%;
   margin-top: -40px;
-  /* filter: drop-shadow(0 0 1rem var(--splashkit-blue)); */
+  /* filter: drop-shadow(0 0 1rem var(--sk-logo-blue)); */
 }
 
 .hero img:hover {
   transform: scale(1.1);
   transition: transform 0.3s ease;
-  /* filter: drop-shadow(0 0 2rem var(--splashkit-blue)); */
+  /* filter: drop-shadow(0 0 2rem var(--sk-logo-blue)); */
 }
 
 [data-has-hero] .page {
@@ -65,17 +70,30 @@ iframe[id="stackblitz-iframe"] {
   margin: 0 auto;
 }
 
-[data-has-hero] .hero .action {
-  border: 1px solid var(--splashkit-blue);
-  transition: background-color ease-in-out 0.25s, color 0.3s ease;
+[data-has-hero] .hero .actions {
+  gap: 1.25rem;
+}
+
+[data-has-hero] .hero .sl-link-button {
+  border: 1px solid var(--link-button-border-color);
+  box-shadow: 0px 0px 5px var(--link-button-border-color);
+  /* transition: background-color ease-in-out 0.25s, color 0.3s ease; */
   position: relative;
   overflow: hidden;
-  /*   background-color: white;
-  color: black; */
   cursor: pointer;
 }
 
-[data-has-hero] .hero .action::before {
+[data-has-hero] .hero .sl-link-button:hover {
+  border: 1px solid var(--link-hover-button-border-color);
+  box-shadow: 0px 0px 10px var(--link-hover-button-border-color);
+}
+
+/* [data-has-hero] .hero .sl-link-button.minimal {
+  border: solid 1px var(--sl-color-text-accent);
+  padding: 1rem 1.25rem;
+} 
+
+[data-has-hero] .hero .sl-link-button::before {
   content: '';
   position: absolute;
   top: 0;
@@ -90,12 +108,12 @@ iframe[id="stackblitz-iframe"] {
   z-index: -1;
 }
 
-[data-has-hero] .hero .action:hover::before {
+[data-has-hero] .hero .sl-link-button:hover::before {
   opacity: 1;
   animation: moveGradient 3s linear infinite;
 }
 
-[data-has-hero] .hero .action:hover {
+[data-has-hero] .hero .sl-link-button:hover {
   color: white;
   background-color: transparent;
 }
@@ -112,18 +130,9 @@ iframe[id="stackblitz-iframe"] {
   100% {
     background-position: 0% 50%;
   }
-}
+} */
 
-[data-has-hero] .hero .action.minimal {
-  border: solid 1px var(--sl-color-text-accent);
-  padding: 1rem 1.25rem;
-}
-
-[data-has-hero] .hero .actions {
-  gap: 1.25rem;
-}
-
-[data-has-hero] .hero .hero-gradient-text {
+/* [data-has-hero] .hero .hero-gradient-text {
   background: radial-gradient(circle at top left,
       hsl(296, 100%, 50%) 0%,
       transparent 50%),
@@ -133,13 +142,49 @@ iframe[id="stackblitz-iframe"] {
   background-clip: text;
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
-}
+} */
 
 /* centre all images/gifs */
 img {
   display: block;
   margin: auto;
 }
+
+/* [data-has-hero] .card {
+  border-radius: 12px;
+  position: relative;
+  background: radial-gradient(
+      300px circle at top left,
+      rgba(85, 44, 190, 0.081) 20%,
+      transparent 100%
+    ),
+    radial-gradient(
+      300px circle at bottom right,
+      rgba(44, 102, 190, 0.09) 20%,
+      transparent 100%
+    );
+}
+
+[data-has-hero] .card::before {
+  content: "";
+  position: absolute;
+  inset: 0px;
+  border-radius: inherit;
+  transition: opacity 400ms ease 0s;
+  will-change: background, opacity;
+  background: radial-gradient(
+    800px circle at var(--mouse-x) var(--mouse-y),
+      rgba(62, 85, 167, 0.212),
+    transparent 40%
+  );
+  opacity: 0;
+  z-index: 2;
+  pointer-events: none;
+}
+
+[data-has-hero] .card:hover::before {
+  opacity: 1;
+} */
 
 [data-has-hero] .star-text {
   margin-top: 8px !important;
@@ -152,6 +197,12 @@ img {
   margin-top: 80px !important;
 }
 
+.home-card {
+  border-radius: 20%;
+  border: 1px dotted black;
+}
+
+/* OS icons on install pages */
 @font-face {
   font-family: "FontAwesomeBrands";
   src: url("/src/fonts/fa-brands-400.woff2") format("woff2");
@@ -160,55 +211,36 @@ img {
   font-display: swap;
 }
 
-.home-card {
-  border-radius: 20%;
-  border: 1px dotted black;
+a.pi:after,
+a.apple:after,
+a.windows:after,
+a.windows-wsl:after,
+a.linux:after {
+  font-family: "FontAwesomeBrands";
+  float: right;
+  border-radius: 5px;
+  border: 1px solid white;
+  padding: 0px 5px 0px 5px;
 }
 
 a.pi:after {
-  font-family: "FontAwesomeBrands";
   content: "\f7bb";
-  float: right;
-  border-radius: 5px;
-  border: 1px solid white;
-  padding: 0px 5px 0px 5px;
 }
 
 a.apple:after {
-  font-family: "FontAwesomeBrands";
   content: "\f179";
-  float: right;
-  border-radius: 5px;
-  border: 1px solid white;
-  padding: 0px 5px 0px 5px;
 }
 
 a.windows:after {
-  font-family: "FontAwesomeBrands";
   content: "\f17a";
-  float: right;
-  border-radius: 5px;
-  border: 1px solid white;
-  padding: 0px 5px 0px 5px;
-
 }
 
 a.windows-wsl:after {
-  font-family: "FontAwesomeBrands";
   content: "\f17a  \f17c";
-  float: right;
-  border-radius: 5px;
-  border: 1px solid white;
-  padding: 0px 5px 0px 5px;
 }
 
 a.linux:after {
-  font-family: "FontAwesomeBrands";
   content: "\f17c";
-  float: right;
-  border-radius: 5px;
-  border: 1px solid white;
-  padding: 0px 5px 0px 5px;
 }
 
 html[data-theme="dark"] a.apple:after,

--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -294,12 +294,12 @@ code {
   transition: transform 0.3s ease, filter 0.3s ease;
   width: 90%;
   height: 90%;
-  filter: drop-shadow(0 0 1rem var(--splashkit-blue));
+  /* filter: drop-shadow(0 0 1rem var(--splashkit-blue)); */
 }
 
 /* Blue shadow background upon hover for the splashkit logo */
 .hero img:hover {
   transform: scale(1.1);
   transition: transform 0.3s ease;
-  filter: drop-shadow(0 0 2rem var(--splashkit-blue));
+  /* filter: drop-shadow(0 0 2rem var(--splashkit-blue)); */
 }

--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -4,38 +4,17 @@
 
 /* Dark mode colors. */
 :root {
+  --splashkit-blue: #00A9E0;
+  --splashkit-blue: #00A9E0;
   --purple-hsl: 255, 60%, 60%;
   --overlay-blurple: hsla(var(--purple-hsl), 0.2);
   /* --table-head-color: rgb(35, 38, 47); */
 }
 
 /* Light mode colors. */
-:root[data-theme="light"] {
-  --purple-hsl: 255, 85%, 65%;
-  --sl-hue-accent: 350;
+:root[data-theme='light'] {
+/*   --sl-color-accent: #00A9E0; */
   --sl-color-accent: #3D50f5;
-
-  /* Potential colours to use when the site can toggle the theme in the future */
-  /* --table-head-color: rgb(244, 245, 247); */
-  /* --table-head-color: hsla(187, 99%, 38%, 0.35); light splashkit blue*/
-  /* --table-head-color: rgb(245, 166, 35);   splashkit orange */
-  /*--table-head-color: rgb(1, 172, 194);     splashkit blue*/
-  /* --table-head-color: rgb(201, 231, 240);	  light blue */
-  /*--table-head-color: rgb(255, 167, 126);   light orange*/
-  /*--table-head-color: rgb(245, 139, 90);	  dark orange*/
-}
-
-.hero img {
-  transition: transform 0.3s ease;
-  width: 90%;
-  height: 90%;
-}
-
-.hero img:hover {
-  transform: scale(1.1);
-  /* Enlarge the image on hover */
-  transition: transform 0.3s ease;
-  /* Add a smooth transition effect */
 }
 
 [data-has-hero] .page {
@@ -69,8 +48,61 @@ iframe[id="stackblitz-iframe"] {
 }
 
 [data-has-hero] .hero .action {
+  border: 1px solid var(--splashkit-blue);
+  transition: background-color ease-in-out 0.25s, color 0.3s ease;
+  position: relative;
+  overflow: hidden;
+/*   background-color: white;
+  color: black; */
+  cursor: pointer;
+}
+
+[data-has-hero] .hero .action::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: linear-gradient(60deg, #FF8300, #00A9E0);
+  background-size: 300% 300%;
+  opacity: 0;
+  transition: opacity 0.3s ease;
   border-radius: 24px;
-  transition: background-color ease-in-out 0.25s;
+  z-index: -1;
+}
+
+[data-has-hero] .hero .action:hover::before {
+  opacity: 1;
+  animation: moveGradient 3s linear infinite;
+}
+
+[data-has-hero] .hero .action:hover {
+  color: white;
+  background-color: transparent;
+}
+
+@keyframes moveGradient {
+  0% { background-position: 0% 50%; }
+  50% { background-position: 100% 50%; }
+  100% { background-position: 0% 50%; }
+  z-index: -1;
+}
+
+[data-has-hero] .hero .action:hover::before {
+  opacity: 1;
+  animation: moveGradient 3s linear infinite;
+}
+
+[data-has-hero] .hero .action:hover {
+  color: white;
+  background-color: transparent;
+}
+
+@keyframes moveGradient {
+  0% { background-position: 0% 50%; }
+  50% { background-position: 100% 50%; }
+  100% { background-position: 0% 50%; }
 }
 
 [data-has-hero] .hero .action.minimal {
@@ -94,40 +126,10 @@ iframe[id="stackblitz-iframe"] {
   -webkit-text-fill-color: transparent;
 }
 
-/* centre all images/gifs in guides */
+/* centre all images/gifs */
 img {
   display: block;
   margin: auto;
-}
-
-[data-has-hero] .card {
-  border-radius: 12px;
-  position: relative;
-  background: radial-gradient(300px circle at top left,
-      rgba(85, 44, 190, 0.081) 20%,
-      transparent 100%),
-    radial-gradient(300px circle at bottom right,
-      rgba(44, 102, 190, 0.09) 20%,
-      transparent 100%);
-}
-
-[data-has-hero] .card::before {
-  content: "";
-  position: absolute;
-  inset: 0px;
-  border-radius: inherit;
-  transition: opacity 400ms ease 0s;
-  will-change: background, opacity;
-  background: radial-gradient(800px circle at var(--mouse-x) var(--mouse-y),
-      rgba(62, 85, 167, 0.212),
-      transparent 40%);
-  opacity: 0;
-  z-index: 2;
-  pointer-events: none;
-}
-
-[data-has-hero] .card:hover::before {
-  opacity: 1;
 }
 
 [data-has-hero] .star-text {
@@ -141,7 +143,6 @@ img {
   margin-top: 80px !important;
 }
 
-/* after */
 @font-face {
   font-family: "FontAwesomeBrands";
   src: url("/src/fonts/fa-brands-400.woff2") format("woff2");
@@ -150,57 +151,35 @@ img {
   font-display: swap;
 }
 
+/* Additional styles for the site and icons */
+
+/* Additional styles for the site and icons */
 .home-card {
   border-radius: 20%;
   border: 1px dotted black;
 }
 
-html[data-theme="dark"] a.multitool:after {
-  border: 1px solid black;
-}
+html[data-theme="dark"] a.multitool:after,
+html[data-theme="dark"] a.apple:after,
+html[data-theme="dark"] a.windows:after,
 
-a.pi:after {
-  font-family: "FontAwesomeBrands";
-  content: "\f7bb";
-  float: right;
-  border-radius: 5px;
-  border: 1px solid white;
-  padding: 0px 5px 0px 5px;
-}
-
-html[data-theme="dark"] a.apple:after {
-  border: 1px solid black;
-}
-
-a.apple:after {
-  font-family: "FontAwesomeBrands";
-  content: "\f179";
-  float: right;
-  border-radius: 5px;
-  border: 1px solid white;
-  padding: 0px 5px 0px 5px;
-}
-
-html[data-theme="dark"] a.windows:after {
-  border: 1px solid black;
-}
-
-a.windows:after {
-  font-family: "FontAwesomeBrands";
-  content: "\f17a";
-  float: right;
-  border-radius: 5px;
-  border: 1px solid white;
-  padding: 0px 5px 0px 5px;
-}
-
+html[data-theme="dark"] a.multitool:after,
+html[data-theme="dark"] a.apple:after,
+html[data-theme="dark"] a.windows:after,
 html[data-theme="dark"] a.linux:after {
   border: 1px solid black;
 }
 
+a.pi:after,
+a.apple:after,
+a.windows:after,
+a.pi:after,
+a.apple:after,
+a.windows:after,
 a.linux:after {
   font-family: "FontAwesomeBrands";
-  content: "\f17c";
+  content: "\f7bb"; /* example, adjust the content value for each specific icon */
+  content: "\f7bb"; /* example, adjust the content value for each specific icon */
   float: right;
   border-radius: 5px;
   border: 1px solid white;
@@ -230,19 +209,6 @@ a.decent {
 
 a.decent:hover {
   color: var(--sl-color-accent) !important;
-}
-
-[data-has-hero] .page {
-  background: linear-gradient(215deg, var(--overlay-blurple), transparent 40%),
-    radial-gradient(var(--overlay-blurple), transparent 40%) no-repeat -60vw -40vh / 105vw 200vh,
-    radial-gradient(var(--overlay-blurple), transparent 65%) no-repeat 50% calc(100% + 20rem) / 60rem 30rem;
-}
-
-[data-has-hero] header {
-  border-bottom: 1px solid transparent;
-  background-color: transparent;
-  -webkit-backdrop-filter: blur(16px);
-  backdrop-filter: blur(16px);
 }
 
 /** Better table styling */
@@ -308,3 +274,19 @@ code {
   border: 1px solid lightgray;
   margin-left: 20px;
 }
+
+/* Applied a blue drop-shadow effect to hero images, enhancing their visibility and focus. */
+.hero img {
+  transition: transform 0.3s ease, filter 0.3s ease;
+  width: 90%;
+  height: 90%;
+  filter: drop-shadow(0 0 1rem var(--splashkit-blue));
+}
+
+/* Blue shadow background upon hover for the splashkit logo */
+.hero img:hover {
+  transform: scale(1.1);
+  transition: transform 0.3s ease;
+  filter: drop-shadow(0 0 2rem var(--splashkit-blue));
+}
+/* Enhanced the hover effect on hero images by increasing the shadow size and applying a slight scale-up animation. */


### PR DESCRIPTION
# Description

This pull request adds in the Thoth Tech (T2 2024) contributions related to updating the website styling.

## Changes

### [Click here to preview all styling changes](https://styling-splashkit-io.netlify.app/)

1. **Updated card/link card styling:** [PR#159](https://github.com/thoth-tech/splashkit.io-starlight/pull/159)
(Note: Some extra animated styling in this PR has been commented out till we create a toggle for animations on the website.)

- Card styling example (simple border using the blue from the tear-drop on the github logo):

| Light | Dark |
| --- | --- |
| <img width="861" alt="image" src="https://github.com/user-attachments/assets/fb19d60f-df7e-46e9-a1fc-87bf378430a5"> | <img width="861" alt="image" src="https://github.com/user-attachments/assets/0933f1cc-f437-47a0-b257-0cbd9413226c"> |

- Link card styling example (using the orange and light blue from splashkit logo - color swaps on hover):

| Light | Dark |
| --- | --- |
| <img width="594" alt="image" src="https://github.com/user-attachments/assets/ce792259-2394-494e-937a-84c784dcf97c"> | <img width="594" alt="image" src="https://github.com/user-attachments/assets/f35f1528-3778-480f-81dc-9668abd2b411"> |

2. **Update/fix table styling:** [PR#187](https://github.com/thoth-tech/splashkit.io-starlight/pull/187)

| Light | Dark |
| --- | --- |
| <img width="582" alt="image" src="https://github.com/user-attachments/assets/3ee6d698-a631-480d-8961-d19f9cb49fee"> | <img width="582" alt="image" src="https://github.com/user-attachments/assets/7e454a16-d7f4-4480-a27e-f943658f423b"> |

3. Remove OS logos from Installation step pages (just keep it on Overview pages) and update Windows WSL logo used: [Commit by omckeon](https://github.com/splashkit/splashkit.io-starlight/commit/c1f9475da785def2c4c4c06789a1c8314727b29b)

| Previous | Updated |
| --- | --- |
| <img width="280" alt="image" src="https://github.com/user-attachments/assets/01b83789-857d-48f5-91f5-e2e466b1dbf9"> | <img width="284" alt="image" src="https://github.com/user-attachments/assets/88183739-dfba-4fdd-b046-dbb1bb896c1e"> |

4. Update Hero styling on front page: [Commit by @omckeon to reduce padding](https://github.com/splashkit/splashkit.io-starlight/commit/20afbe78be36afdc9fd6e11860d27a3174cd0c80) and [Commit by @omckeon to fix button styling](https://github.com/splashkit/splashkit.io-starlight/commit/f7d1fa25a2c5ebf3dff628063b420e1921ca44ae)

| Previous | Updated |
| --- | --- |
| <img width="1308" alt="image" src="https://github.com/user-attachments/assets/71accb91-76f1-426b-90f2-2a6acb3c3df1"> | <img width="1308" alt="image" src="https://github.com/user-attachments/assets/ef501913-9f8c-42b5-89e5-3b2b6632c95d"> |

## How Has This Been Tested?

- [X] Tested in latest Chrome
- [X] Tested in latest Firefox
- [X] npm run build
- [X] npm run preview