### PR TITLE
Update to the README page

### DIFF
--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -3,54 +3,71 @@
 Follow these steps to contribute to the SplashKit website repository:
 
 1. **Fork the Repository:**
+
    - Visit the SplashKit repository on GitHub.
    - Click on the "Fork" button in the top-right corner of the page. This will create a copy of the repository under your GitHub account.
 
 2. **Clone Your Fork:**
+
    - Open your terminal or Git client.
    - Clone your forked repository to your local machine using the following command:
 
-     ```shell
-     git clone https://github.com/YOUR_USERNAME/splashkit.git
-     ```
+    ```shell
+    git clone https://github.com/YOUR_USERNAME/splashkit.git
+    ```
 
-3. **Make Your Changes:**
+3. **Checkout new branch:**
+
+   - Open your terminal or Git client.
+   - Create a new branch on your forked repository using the following command (replace `<new-branch>` with your chosen name):
+
+    ```shell
+    git checkout -b ＜new-branch＞
+    ```
+
+4. **Make Your Changes:**
+
    - Navigate to the project directory on your local machine.
    - Make your respective changes, ensuring high-quality contributions.
 
-4. **Commit Your Changes:**
+5. **Commit Your Changes:**
+
    - After making changes, commit them with meaningful commit messages.
 
-     ```shell
-     git add .
-     git commit -m "Your descriptive commit message"
-     ```
+    ```shell
+    git add .
+    git commit -m "Your descriptive commit message"
+    ```
 
-5. **Push Changes to Your Fork:**
+6. **Push Changes to Your Fork:**
+
    - Push your changes to your forked repository on GitHub.
 
-     ```shell
-     git push origin master
-     ```
+    ```shell
+    git push origin master
+    ```
 
-6. **Create a Pull Request (PR):**
+7. **Create a Pull Request (PR):**
+
    - Visit your forked repository on GitHub.
    - Click on the "New Pull Request" button.
-   - Ensure the base repository is set to `splashkit/splashkit` and the base branch is `main`.
-   - Ensure the head repository is set to `YOUR_USERNAME/splashkit` and the compare branch is `master`.
+   - Ensure the base and head repositories have been set correctly.
    - Click on "Create Pull Request."
 
-7. **Wait for Review:**
+8. **Wait for Review:**
+
    - The maintainers will review your PR. Be patient, and be ready to respond to any feedback or comments.
    - If changes are requested, make the necessary updates and push them to your forked repository.
 
-8. **Follow Up to Comments:**
+9. **Follow Up to Comments:**
+
    - Engage with any comments or questions from the maintainers.
    - If additional changes are needed, repeat steps 4-7.
 
-9. **PR Approval/Rejection:**
-   - Once your changes are approved, the maintainers will merge your PR into the main repository.
-   - If your changes are rejected, understand the feedback and consider making improvements before submitting another PR.
+10. **PR Approval/Rejection:**
+
+    - Once your changes are approved, the maintainers will merge your PR into the main repository.
+    - If your changes are rejected, understand the feedback and consider making improvements before submitting another PR.
 
 By following these steps, you contribute effectively to the SplashKit website. Remember to adhere to the project's guidelines and maintain a collaborative and respectful environment.
 
@@ -68,7 +85,7 @@ The SplashKit website project structure is organized as follows:
 
 ```plaintext
 .
-├── public/                   # Publicly accessible resources
+├── public/               # Publicly accessible resources
 │   ├── gifs/                 # GIF files used across the website
 │   ├── images/               # General image resources
 │   ├── resources/            # Resource files for various purposes
@@ -77,14 +94,13 @@ The SplashKit website project structure is organized as follows:
 │   ├── assets/               # Additional assets for the website
 │   ├── components/           # Reusable UI components
 │   ├── content/              # Documentation and content files
-│   │   ├── docs/             # Main documentation directory
-│   │   ├── guides/           # Guides for specific features
-│   │   ├── installation/     # Installation instructions
-│   │   ├── troubleshoot/     # Troubleshooting information
-│   │   └── arcade-hackathon-project/ # Arcade hackathon resources
+│   │   ├── docs/                 # Main documentation directory
+│   │   ├── guides/               # Guides for specific features
+│   │   ├── installation/         # Installation instructions
+│   │   ├── troubleshoot/         # Troubleshooting information
 │   ├── fonts/                # Custom fonts used on the site
 │   ├── styles/               # Global and component CSS styles
-└── test/                     # Scripts for testing and page generation
+└── test/                 # Scripts for testing and page generation
 ```
 
 ### Image and Usage Example Resources

--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -56,30 +56,57 @@ By following these steps, you contribute effectively to the SplashKit website. R
 
 ## Website Guide
 
-<!-- TODO: Update the information below -->
-
-This guide provides information on the structure and organization of the SplashKit website using the Starlight framework. Follow these instructions to navigate through the project and make necessary updates.
+This guide provides information on the structure and organization of the SplashKit website, which is built on the Starlight framework. Follow these instructions to navigate through the project and make necessary updates effectively.
 
 ### Installation and Commands
 
-For basic installation and commands, please refer to the [`Readme.md`](/README.md) file in the project's root directory.
+For detailed installation instructions and common commands, refer to the [`README.md`](/README.md) file in the root directory of the project.
 
-### Image Resources
+### Project Structure Overview
 
-All image resources are located under the `public` root directory.
+The SplashKit website project structure is organized as follows:
+
+```plaintext
+.
+├── public/                   # Publicly accessible resources
+│   ├── gifs/                 # GIF files used across the website
+│   ├── images/               # General image resources
+│   ├── resources/            # Resource files for various purposes
+│   └── usage-examples/       # Files for usage examples
+├── src/
+│   ├── assets/               # Additional assets for the website
+│   ├── components/           # Reusable UI components
+│   ├── content/              # Documentation and content files
+│   │   ├── docs/             # Main documentation directory
+│   │   ├── guides/           # Guides for specific features
+│   │   ├── installation/     # Installation instructions
+│   │   ├── troubleshoot/     # Troubleshooting information
+│   │   └── arcade-hackathon-project/ # Arcade hackathon resources
+│   ├── fonts/                # Custom fonts used on the site
+│   ├── styles/               # Global and component CSS styles
+└── test/                     # Scripts for testing and page generation
+```
+
+### Image and Usage Example Resources
+
+All image resources are located in the `public/images` directory.
+
+Usage examples, which illustrate how to use different SplashKit functions, are organized under the `public/usage-examples/` directory. Ensure that any new usage example files are placed here.
 
 ### Documentation Pages
 
-Documentation pages are stored under `root/src/content/docs/`. To find information on specific SplashKit components such as Animations, Sounds, etc., refer to the respective sections within the `components` directory.
+Documentation pages are stored under `src/content/docs/`. For sections related to specific components, such as Animations, Sounds, or other SplashKit features, refer to the respective subdirectories within `src/content/docs/components`.
 
-Each working directory can contain an `index.mdx` file. This file serves as the page that will be accessed when only the section is fetched. For instance, under the `installation` directory, the `index.mdx` page will be accessed when `https://some-host/installation/` is fetched.
+- Each section may include an `index.mdx` file, which serves as the main page when navigating to a section URL (e.g., the `index.mdx` file in the `installation` folder is accessed via `https://your-site/installation/`).
 
-### CSS Files
+### Styling and CSS Files
 
-CSS files can be found under `src/styles/`. If you create a new directory or use new style files, update the `astro.config.mjs` file in the root directory to read the files.
+All CSS files can be found under the `src/styles/` directory. If you add new CSS files or directories, ensure they are referenced in the `astro.config.mjs` file in the root directory to apply styles correctly across the website.
 
 ### Test Directory
 
-Inside the `test` directory, you will find a NodeJS script that generates MDX pages required for component generation. Refer to the comments inside the script for detailed instructions on usage and customization.
+The `test` directory contains scripts, including a NodeJS script that generates MDX pages needed for component generation. Refer to comments within each script for specific instructions on usage and customization.
 
-Make sure to follow these guidelines to maintain a well-organized and functional SplashKit website powered by the Starlight framework.
+### Guidelines
+
+Adhere to these structure and organization guidelines to maintain a functional, well-organized SplashKit website on the Starlight framework. Consistency across directories and files will streamline contributions and enhance project maintainability.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
     <img width="150px" src="https://github.com/thoth-tech/.github/blob/main/images/splashkit.png"/>
 </p>
 
-### Splashkit Stats
+### [Splashkit](https://github.com/splashkit/splashkit.io-starlight) Stats
 
 [![GitHub contributors](https://img.shields.io/github/contributors/splashkit/splashkit.io-starlight?label=Contributors&color=F5A623)](https://github.com/splashkit/splashkit.io-starlight/graphs/contributors)
 [![GitHub issues](https://img.shields.io/github/issues/splashkit/splashkit.io-starlight?label=Issues&color=F5A623)](https://github.com/splashkit/splashkit.io-starlight/issues)
@@ -12,7 +12,7 @@
 ![Forks](https://img.shields.io/github/forks/splashkit/splashkit.io-starlight?label=Forks&color=F5A623)
 ![Stars](https://img.shields.io/github/stars/splashkit/splashkit.io-starlight?label=Stars&color=F5A623)
 
-### Thoth Tech Stats
+### [Thoth Tech](https://github.com/thoth-tech/splashkit.io-starlight) Stats
 
 [![GitHub contributors](https://img.shields.io/github/contributors/thoth-tech/splashkit.io-starlight?label=Contributors&color=F5A623)](https://github.com/thoth-tech/splashkit.io-starlight/graphs/contributors)
 [![GitHub issues](https://img.shields.io/github/issues/thoth-tech/splashkit.io-starlight?label=Issues&color=F5A623)](https://github.com/thoth-tech/splashkit.io-starlight/issues)

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 ![GitHub contributors](https://img.shields.io/github/contributors/splashkit/splashkit.io-starlight?label=Contributors&color=F5A623)
 ![GitHub issues](https://img.shields.io/github/issues/splashkit/splashkit.io-starlight?label=Issues&color=F5A623)
 ![GitHub pull requests](https://img.shields.io/github/issues-pr/splashkit/splashkit.io-starlight?label=Pull%20Requests&color=F5A623)
-![Website](https://img.shields.io/website?down_color=red&down_message=offline&label=Website&up_color=green&up_message=online&url=https%3A%2F%2Fsplashkit.io)
+[![Website](https://img.shields.io/website?down_color=red&down_message=offline&label=Website&up_color=green&up_message=online&url=https%3A%2F%2Fsplashkit.io)](https://splashkit.io/)
 ![Netlify](https://img.shields.io/netlify/29627b16-8f40-4b42-8ae8-1912895f5305?label=Netlify&color=F5A623)
 ![Forks](https://img.shields.io/github/forks/splashkit/splashkit.io-starlight?label=Forks&color=F5A623)
 ![Stars](https://img.shields.io/github/stars/splashkit/splashkit.io-starlight?label=Stars&color=F5A623)

--- a/README.md
+++ b/README.md
@@ -98,15 +98,6 @@ All commands are run from the root of the project, from a terminal:
 | `npm run generate-usage-examples-pages` | Runs the script to generate usage example pages from the `./scripts/usage-example-page-generation.cjs` file |
 | `npm run check-links`                   | Sets `CHECK_LINKS=true`, runs `npm run build`, then resets `CHECK_LINKS=false`                              |
 
-## 🧞 Starting the Development Environment
-
-To start the SplashKit website development environment, you can use the predefined tasks in the `tasks.json` file:
-
-1. Press `Ctrl+Shift+P` to open the command palette.
-2. Select **"Run Task"** and choose **"Build splashkit.io Website"** from the list. This will build the project.
-3. After the build is complete, open the command palette again with `Ctrl+Shift+P`.
-4. Select **"Run Task"** and then **"Serve splashkit.io Website"** to start the local server.
-
 ## Contributing
 
 We welcome contributions from the community to enhance the SplashKit SDK on the Starlight framework. If you would like to contribute, please follow the guidelines outlined in the [CONTRIBUTE.md](./CONTRIBUTE.md) file.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="left">
-    <img width="150px" src="https://github.com/thoth-tech/.github/blob/main/images/splashkit.png"/>
+    <img width="150px" src="https://github.com/thoth-tech/.github/blob/main/images/splashkit.png" alt="SplashKit Logo"/>
 </p>
 
 ### [Splashkit](https://github.com/splashkit/splashkit.io-starlight) Stats
@@ -20,7 +20,6 @@
 [![Website Preview](https://img.shields.io/badge/Preview-splashkit.io-blue)](https://splashkit-io.netlify.app/)
 ![Forks](https://img.shields.io/github/forks/thoth-tech/splashkit.io-starlight?label=Forks&color=F5A623)
 ![Stars](https://img.shields.io/github/stars/thoth-tech/splashkit.io-starlight?label=Stars&color=F5A623)
-
 
 # SplashKit SDK - Starlight Framework
 
@@ -98,6 +97,15 @@ All commands are run from the root of the project, from a terminal:
 | `npm run generate-mdx`                  | Generates an MDX file *(for functions)* from JSON data in the `test` folder                                 |
 | `npm run generate-usage-examples-pages` | Runs the script to generate usage example pages from the `./scripts/usage-example-page-generation.cjs` file |
 | `npm run check-links`                   | Sets `CHECK_LINKS=true`, runs `npm run build`, then resets `CHECK_LINKS=false`                              |
+
+## 🧞 Starting the Development Environment
+
+To start the SplashKit website development environment, you can use the predefined tasks in the `tasks.json` file:
+
+1. Press `Ctrl+Shift+P` to open the command palette.
+2. Select **"Run Task"** and choose **"Build splashkit.io Website"** from the list. This will build the project.
+3. After the build is complete, open the command palette again with `Ctrl+Shift+P`.
+4. Select **"Run Task"** and then **"Serve splashkit.io Website"** to start the local server.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@
 
 ### [Thoth Tech](https://github.com/thoth-tech/splashkit.io-starlight) Stats
 
+Thoth Tech is a people-focused educational technology company dedicated to empowering students and educators through innovative tools. As a capstone company in Deakin University's capstone subjects, Thoth Tech provides real-world learning opportunities and contributes significantly to projects like SplashKit, enhancing its capabilities and resources
+
 [![GitHub contributors](https://img.shields.io/github/contributors/thoth-tech/splashkit.io-starlight?label=Contributors&color=F5A623)](https://github.com/thoth-tech/splashkit.io-starlight/graphs/contributors)
 [![GitHub issues](https://img.shields.io/github/issues/thoth-tech/splashkit.io-starlight?label=Issues&color=F5A623)](https://github.com/thoth-tech/splashkit.io-starlight/issues)
 [![GitHub pull requests](https://img.shields.io/github/issues-pr/thoth-tech/splashkit.io-starlight?label=Pull%20Requests&color=F5A623)](https://github.com/thoth-tech/splashkit.io-starlight/pulls)

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 ### [Thoth Tech](https://github.com/thoth-tech/splashkit.io-starlight) Stats
 
-Thoth Tech is a people-focused educational technology company dedicated to empowering students and educators through innovative tools. As a capstone company in Deakin University's capstone subjects, Thoth Tech provides real-world learning opportunities and contributes significantly to projects like SplashKit, enhancing its capabilities and resources
+Thoth Tech is a people-focused educational technology company dedicated to empowering students and educators through innovative tools. As a capstone company in Deakin University's capstone subjects, Thoth Tech provides real-world learning opportunities and contributes significantly to projects like SplashKit, enhancing its capabilities and resources.
 
 [![GitHub contributors](https://img.shields.io/github/contributors/thoth-tech/splashkit.io-starlight?label=Contributors&color=F5A623)](https://github.com/thoth-tech/splashkit.io-starlight/graphs/contributors)
 [![GitHub issues](https://img.shields.io/github/issues/thoth-tech/splashkit.io-starlight?label=Issues&color=F5A623)](https://github.com/thoth-tech/splashkit.io-starlight/issues)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Introduction
 
-Welcome to the official documentation for the SplashKit SDK on the Starlight framework! This README markdown script will guide you through the installation process and provide an overview of the features and functionalities of the SDK.
+Welcome to the official documentation for the SplashKit SDK on the Starlight framework! This README will guide you through the installation process and provide an overview of the features and functionalities of the SDK.
 
 ## Deployment Status
 
@@ -13,11 +13,11 @@ Welcome to the official documentation for the SplashKit SDK on the Starlight fra
 
 ## Installation
 
-1. Install and open Docker app.
-2. Fork then clone this repository.
-3. Reopen cloned repository in container (pop-up may appear in VS Code)
-
 If needed:
+
+1. Install and open Docker: Ensure Docker is installed and running on your machine.
+2. Fork and clone this repository: This allows you to make your own changes and submit them if needed.
+3. Reopen the cloned repository in a container: You may get a prompt to open it in a container in VS Code; select "Reopen in Container."
 
 - Install the necessary dependencies. Make sure you have the following installed:
 
@@ -32,6 +32,11 @@ Inside of your Astro + Starlight project, you'll see the following folders and f
 ```plaintext
 .
 ├── public/
+│   ├── gifs/
+│   ├── images/
+│   ├── resources/
+│   └── usage-examples/
+├── scripts/
 └── src/
     ├── assets/
     ├── components/
@@ -40,7 +45,8 @@ Inside of your Astro + Starlight project, you'll see the following folders and f
     │   │   ├── api/
     │   │   ├── guides/
     │   │   ├── installation/
-    │   │   └── troubleshoot/
+    │   │   ├── troubleshoot/
+    │   │   └── arcade-hackathon-project/
     ├── fonts/
     ├── styles/
     <!-- ├── config.ts -->
@@ -50,25 +56,25 @@ Inside of your Astro + Starlight project, you'll see the following folders and f
 └── tsconfig.json
 ```
 
-Starlight looks for `.md` or `.mdx` files in the `src/content/docs/` directory. Each file is exposed as a route based on its file name.
-
-Images can be added to `src/assets/` and embedded in Markdown with a relative link.
-
-Static assets, like favicons and gifs, can be placed in the `public/` directory.
+- **Documentation Files**: Starlight looks for `.md` or `.mdx` files in the `src/content/docs/` directory. Each file is exposed as a route based on its file name.
+- **Images and Assets**: Images can be added to `src/assets/` and embedded in Markdown with a relative link.
+- **Static Assets**: Static assets, like favicons and gifs, can be placed in the `public/` directory.
 
 ## 🧞 Commands
 
 All commands are run from the root of the project, from a terminal:
 
-| Command                   | Action                                           |
-| :------------------------ | :----------------------------------------------- |
-| `npm install`             | Installs dependencies                            |
-| `npm run dev`             | Starts local dev server at `localhost:3000`      |
-| `npm run build`           | Build your production site to `./dist/`          |
-| `npm run preview`         | Preview your build locally, before deploying     |
-| `npm run astro ...`       | Run CLI commands like `astro add`, `astro check` |
-| `npm run astro -- --help` | Get help using the Astro CLI                     |
-| `npm run generate-mdx`             | Generate MDX file *(for functions)* from JSON data in `test` folder                   |
+| Command                                 | Action                                                                                                      |
+| :-------------------------------------- | :---------------------------------------------------------------------------------------------------------- |
+| `npm install`                           | Installs dependencies                                                                                       |
+| `npm run dev`                           | Starts local dev server at `localhost:4322`                                                                 |
+| `npm run build`                         | Builds your production site to `./dist/`                                                                    |
+| `npm run preview`                       | Previews your build locally, before deploying                                                               |
+| `npm run astro ...`                     | Runs CLI commands like `astro add`, `astro check`                                                           |
+| `npm run astro -- --help`               | Gets help using the Astro CLI                                                                               |
+| `npm run generate-mdx`                  | Generates an MDX file *(for functions)* from JSON data in the `test` folder                                 |
+| `npm run generate-usage-examples-pages` | Runs the script to generate usage example pages from the `./scripts/usage-example-page-generation.cjs` file |
+| `npm run check-links`                   | Sets `CHECK_LINKS=true`, runs `npm run build`, then resets `CHECK_LINKS=false`                              |
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -2,15 +2,37 @@
     <img width="150px" src="https://github.com/thoth-tech/.github/blob/main/images/splashkit.png"/>
 </p>
 
+### Splashkit Stats
+
+![GitHub contributors](https://img.shields.io/github/contributors/splashkit/splashkit.io-starlight?label=Contributors&color=F5A623)
+![GitHub issues](https://img.shields.io/github/issues/splashkit/splashkit.io-starlight?label=Issues&color=F5A623)
+![GitHub pull requests](https://img.shields.io/github/issues-pr/splashkit/splashkit.io-starlight?label=Pull%20Requests&color=F5A623)
+![Forks](https://img.shields.io/github/forks/splashkit/splashkit.io-starlight?label=Forks&color=F5A623)
+![Stars](https://img.shields.io/github/stars/splashkit/splashkit.io-starlight?label=Stars&color=F5A623)
+![Website](https://img.shields.io/website?down_color=red&down_message=offline&label=Website&up_color=green&up_message=online&url=https%3A%2F%2Fsplashkit.io)
+![Netlify](https://img.shields.io/netlify/29627b16-8f40-4b42-8ae8-1912895f5305?label=Netlify&color=F5A623)
+
+
+### Thoth Tech Stats
+
+![GitHub contributors](https://img.shields.io/github/contributors/thoth-tech/splashkit.io-starlight?label=Contributors&color=F5A623)
+![GitHub issues](https://img.shields.io/github/issues/thoth-tech/splashkit.io-starlight?label=Issues&color=F5A623)
+![GitHub pull requests](https://img.shields.io/github/issues-pr/thoth-tech/splashkit.io-starlight?label=Pull%20Requests&color=F5A623)
+![Forks](https://img.shields.io/github/forks/thoth-tech/splashkit.io-starlight?label=Forks&color=F5A623)
+![Stars](https://img.shields.io/github/stars/thoth-tech/splashkit.io-starlight?label=Stars&color=F5A623)
+![Website](https://img.shields.io/website?down_color=red&down_message=offline&label=Website&up_color=green&up_message=online&url=https%3A%2F%2Fsplashkit.io)
+![Netlify](https://img.shields.io/netlify/29627b16-8f40-4b42-8ae8-1912895f5305?label=Netlify&color=F5A623)
+[![Website Preview](https://img.shields.io/badge/Preview-splashkit.io-blue)](https://splashkit-io.netlify.app/)
+
+
 # SplashKit SDK - Starlight Framework
 
 ## Introduction
 
 Welcome to the official documentation for the SplashKit SDK on the Starlight framework! This README will guide you through the installation process and provide an overview of the features and functionalities of the SDK.
 
-## Deployment Status
-
-[Thoth Tech's 'splashkit.io' Site](https://splashkit-io.netlify.app/) - [![Netlify Status](https://api.netlify.com/api/v1/badges/e8def4e6-f39d-458a-8ca9-556d61ce1fbd/deploy-status)](https://app.netlify.com/sites/splashkit-io/deploys)
+<!--## Deployment Status!-->
+<!--[Thoth Tech's 'splashkit.io' Site](https://splashkit-io.netlify.app/) - [![Netlify Status](https://api.netlify.com/api/v1/badges/e8def4e6-f39d-458a-8ca9-556d61ce1fbd/deploy-status)](https://app.netlify.com/sites/splashkit-io/deploys)--!>
 
 <!-- - [Production](https://master--splashkit.netlify.app/) -   [![Netlify Status](https://api.netlify.com/api/v1/badges/29627b16-8f40-4b42-8ae8-1912895f5305/deploy-status?branch=master)](https://app.netlify.com/sites/splashkit/deploys) ![Github Pages](https://github.com/splashkit/splashkit.io-starlight/actions/workflows/astro.yml/badge.svg?branch=master)
 - [Development](https://development--splashkit.netlify.app/) - [![Netlify Status](https://api.netlify.com/api/v1/badges/29627b16-8f40-4b42-8ae8-1912895f5305/deploy-status?branch=development)](https://app.netlify.com/sites/splashkit/deploys) ![Github Pages](https://github.com/splashkit/splashkit.io-starlight/actions/workflows/astro.yml/badge.svg?branch=production) -->
@@ -82,4 +104,4 @@ All commands are run from the root of the project, from a terminal:
 
 ## Contributing
 
-We welcome contributions from the community to enhance the SplashKit SDK on the Starlight framework. If you would like to contribute, please follow the guidelines outlined in the CONTRIBUTING.md file.
+We welcome contributions from the community to enhance the SplashKit SDK on the Starlight framework. If you would like to contribute, please follow the guidelines outlined in the [CONTRIBUTE.md](./CONTRIBUTE.md) file.

--- a/README.md
+++ b/README.md
@@ -7,23 +7,19 @@
 ![GitHub contributors](https://img.shields.io/github/contributors/splashkit/splashkit.io-starlight?label=Contributors&color=F5A623)
 ![GitHub issues](https://img.shields.io/github/issues/splashkit/splashkit.io-starlight?label=Issues&color=F5A623)
 ![GitHub pull requests](https://img.shields.io/github/issues-pr/splashkit/splashkit.io-starlight?label=Pull%20Requests&color=F5A623)
-![Forks](https://img.shields.io/github/forks/splashkit/splashkit.io-starlight?label=Forks&color=F5A623)
-![Stars](https://img.shields.io/github/stars/splashkit/splashkit.io-starlight?label=Stars&color=F5A623)
 ![Website](https://img.shields.io/website?down_color=red&down_message=offline&label=Website&up_color=green&up_message=online&url=https%3A%2F%2Fsplashkit.io)
 ![Netlify](https://img.shields.io/netlify/29627b16-8f40-4b42-8ae8-1912895f5305?label=Netlify&color=F5A623)
-
+![Forks](https://img.shields.io/github/forks/splashkit/splashkit.io-starlight?label=Forks&color=F5A623)
+![Stars](https://img.shields.io/github/stars/splashkit/splashkit.io-starlight?label=Stars&color=F5A623)
 
 ### Thoth Tech Stats
 
 ![GitHub contributors](https://img.shields.io/github/contributors/thoth-tech/splashkit.io-starlight?label=Contributors&color=F5A623)
 ![GitHub issues](https://img.shields.io/github/issues/thoth-tech/splashkit.io-starlight?label=Issues&color=F5A623)
 ![GitHub pull requests](https://img.shields.io/github/issues-pr/thoth-tech/splashkit.io-starlight?label=Pull%20Requests&color=F5A623)
+[![Website Preview](https://img.shields.io/badge/Preview-splashkit.io-blue)](https://splashkit-io.netlify.app/)
 ![Forks](https://img.shields.io/github/forks/thoth-tech/splashkit.io-starlight?label=Forks&color=F5A623)
 ![Stars](https://img.shields.io/github/stars/thoth-tech/splashkit.io-starlight?label=Stars&color=F5A623)
-![Website](https://img.shields.io/website?down_color=red&down_message=offline&label=Website&up_color=green&up_message=online&url=https%3A%2F%2Fsplashkit.io)
-![Netlify](https://img.shields.io/netlify/29627b16-8f40-4b42-8ae8-1912895f5305?label=Netlify&color=F5A623)
-[![Website Preview](https://img.shields.io/badge/Preview-splashkit.io-blue)](https://splashkit-io.netlify.app/)
-
 
 # SplashKit SDK - Starlight Framework
 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 
 ### Splashkit Stats
 
-![GitHub contributors](https://img.shields.io/github/contributors/splashkit/splashkit.io-starlight?label=Contributors&color=F5A623)
-![GitHub issues](https://img.shields.io/github/issues/splashkit/splashkit.io-starlight?label=Issues&color=F5A623)
-![GitHub pull requests](https://img.shields.io/github/issues-pr/splashkit/splashkit.io-starlight?label=Pull%20Requests&color=F5A623)
+[![GitHub contributors](https://img.shields.io/github/contributors/splashkit/splashkit.io-starlight?label=Contributors&color=F5A623)](https://github.com/splashkit/splashkit.io-starlight/graphs/contributors)
+[![GitHub issues](https://img.shields.io/github/issues/splashkit/splashkit.io-starlight?label=Issues&color=F5A623)](https://github.com/splashkit/splashkit.io-starlight/issues)
+[![GitHub pull requests](https://img.shields.io/github/issues-pr/splashkit/splashkit.io-starlight?label=Pull%20Requests&color=F5A623)](https://github.com/splashkit/splashkit.io-starlight/pulls)
 [![Website](https://img.shields.io/website?down_color=red&down_message=offline&label=Website&up_color=green&up_message=online&url=https%3A%2F%2Fsplashkit.io)](https://splashkit.io/)
 ![Netlify](https://img.shields.io/netlify/29627b16-8f40-4b42-8ae8-1912895f5305?label=Netlify&color=F5A623)
 ![Forks](https://img.shields.io/github/forks/splashkit/splashkit.io-starlight?label=Forks&color=F5A623)
@@ -14,12 +14,13 @@
 
 ### Thoth Tech Stats
 
-![GitHub contributors](https://img.shields.io/github/contributors/thoth-tech/splashkit.io-starlight?label=Contributors&color=F5A623)
-![GitHub issues](https://img.shields.io/github/issues/thoth-tech/splashkit.io-starlight?label=Issues&color=F5A623)
-![GitHub pull requests](https://img.shields.io/github/issues-pr/thoth-tech/splashkit.io-starlight?label=Pull%20Requests&color=F5A623)
+[![GitHub contributors](https://img.shields.io/github/contributors/thoth-tech/splashkit.io-starlight?label=Contributors&color=F5A623)](https://github.com/thoth-tech/splashkit.io-starlight/graphs/contributors)
+[![GitHub issues](https://img.shields.io/github/issues/thoth-tech/splashkit.io-starlight?label=Issues&color=F5A623)](https://github.com/thoth-tech/splashkit.io-starlight/issues)
+[![GitHub pull requests](https://img.shields.io/github/issues-pr/thoth-tech/splashkit.io-starlight?label=Pull%20Requests&color=F5A623)](https://github.com/thoth-tech/splashkit.io-starlight/pulls)
 [![Website Preview](https://img.shields.io/badge/Preview-splashkit.io-blue)](https://splashkit-io.netlify.app/)
 ![Forks](https://img.shields.io/github/forks/thoth-tech/splashkit.io-starlight?label=Forks&color=F5A623)
 ![Stars](https://img.shields.io/github/stars/thoth-tech/splashkit.io-starlight?label=Stars&color=F5A623)
+
 
 # SplashKit SDK - Starlight Framework
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+<p align="left">
+    <img width="150px" src="https://github.com/thoth-tech/.github/blob/main/images/splashkit.png"/>
+</p>
+
 # SplashKit SDK - Starlight Framework
 
 ## Introduction

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
-<p align="left">
-    <img width="150px" src="https://github.com/thoth-tech/.github/blob/main/images/splashkit.png" alt="SplashKit Logo"/>
-</p>
+# [splashkit.io](https://splashkit.io) Website - Starlight Framework
 
-### [Splashkit](https://github.com/splashkit/splashkit.io-starlight) Stats
+<img width="150px" align="right" src="https://github.com/thoth-tech/.github/blob/main/images/splashkit.png" alt="SplashKit Logo"/>
+
+Welcome to the official documentation website for the SplashKit SDK, using the Starlight (Astro) framework! This README will guide you through the installation process and provide an overview of the features and functionalities of the SDK.
+
+[splashkit/splashkit.io-starlight](https://github.com/splashkit/splashkit.io-starlight)
 
 [![GitHub contributors](https://img.shields.io/github/contributors/splashkit/splashkit.io-starlight?label=Contributors&color=F5A623)](https://github.com/splashkit/splashkit.io-starlight/graphs/contributors)
 [![GitHub issues](https://img.shields.io/github/issues/splashkit/splashkit.io-starlight?label=Issues&color=F5A623)](https://github.com/splashkit/splashkit.io-starlight/issues)
@@ -12,9 +14,7 @@
 ![Forks](https://img.shields.io/github/forks/splashkit/splashkit.io-starlight?label=Forks&color=F5A623)
 ![Stars](https://img.shields.io/github/stars/splashkit/splashkit.io-starlight?label=Stars&color=F5A623)
 
-### [Thoth Tech](https://github.com/thoth-tech/splashkit.io-starlight) Stats
-
-Thoth Tech is a people-focused educational technology company dedicated to empowering students and educators through innovative tools. As a capstone company in Deakin University's capstone subjects, Thoth Tech provides real-world learning opportunities and contributes significantly to projects like SplashKit, enhancing its capabilities and resources.
+[thoth-tech/splashkit.io-starlight](https://github.com/thoth-tech/splashkit.io-starlight) *
 
 [![GitHub contributors](https://img.shields.io/github/contributors/thoth-tech/splashkit.io-starlight?label=Contributors&color=F5A623)](https://github.com/thoth-tech/splashkit.io-starlight/graphs/contributors)
 [![GitHub issues](https://img.shields.io/github/issues/thoth-tech/splashkit.io-starlight?label=Issues&color=F5A623)](https://github.com/thoth-tech/splashkit.io-starlight/issues)
@@ -23,17 +23,9 @@ Thoth Tech is a people-focused educational technology company dedicated to empow
 ![Forks](https://img.shields.io/github/forks/thoth-tech/splashkit.io-starlight?label=Forks&color=F5A623)
 ![Stars](https://img.shields.io/github/stars/thoth-tech/splashkit.io-starlight?label=Stars&color=F5A623)
 
-# SplashKit SDK - Starlight Framework
+**\* SplashKit Development in Thoth Tech**
 
-## Introduction
-
-Welcome to the official documentation for the SplashKit SDK on the Starlight framework! This README will guide you through the installation process and provide an overview of the features and functionalities of the SDK.
-
-<!--## Deployment Status!-->
-<!--[Thoth Tech's 'splashkit.io' Site](https://splashkit-io.netlify.app/) - [![Netlify Status](https://api.netlify.com/api/v1/badges/e8def4e6-f39d-458a-8ca9-556d61ce1fbd/deploy-status)](https://app.netlify.com/sites/splashkit-io/deploys)--!>
-
-<!-- - [Production](https://master--splashkit.netlify.app/) -   [![Netlify Status](https://api.netlify.com/api/v1/badges/29627b16-8f40-4b42-8ae8-1912895f5305/deploy-status?branch=master)](https://app.netlify.com/sites/splashkit/deploys) ![Github Pages](https://github.com/splashkit/splashkit.io-starlight/actions/workflows/astro.yml/badge.svg?branch=master)
-- [Development](https://development--splashkit.netlify.app/) - [![Netlify Status](https://api.netlify.com/api/v1/badges/29627b16-8f40-4b42-8ae8-1912895f5305/deploy-status?branch=development)](https://app.netlify.com/sites/splashkit/deploys) ![Github Pages](https://github.com/splashkit/splashkit.io-starlight/actions/workflows/astro.yml/badge.svg?branch=production) -->
+Thoth Tech is a people-focused educational technology company within Deakin University's capstone program which provides real-world learning opportunities and allows students to contribute significantly to projects like SplashKit, enhancing its capabilities and resources.
 
 ## Installation
 
@@ -98,6 +90,7 @@ All commands are run from the root of the project, from a terminal:
 | `npm run astro -- --help`               | Gets help using the Astro CLI                                                                               |
 | `npm run generate-mdx`                  | Generates an MDX file *(for functions)* from JSON data in the `test` folder                                 |
 | `npm run generate-usage-examples-pages` | Runs the script to generate usage example pages from the `./scripts/usage-example-page-generation.cjs` file |
+| `npm run generate-usage-examples-pages write_line-1-simple` | Runs the script to generate usage example pages from the `./scripts/usage-example-page-generation.cjs` file and prints the testing output for the `write_line-1-simple` example |
 | `npm run check-links`                   | Sets `CHECK_LINKS=true`, runs `npm run build`, then resets `CHECK_LINKS=false`                              |
 
 ## Contributing


### PR DESCRIPTION
# Update README

## Description
This PR enhances the README documentation for the SplashKit Starlight site. The changes aim to provide clearer instructions, a more organised project structure, and updated command details to help contributors and users navigate the project effectively.

### Key Updates

1. **Expanded Project Structure**: Added a detailed project structure to reflect the current file organisation, including:
   - New `scripts/` folder.
   - Updated `public/` directory with `gifs/`, `images/`, `resources/`, and `usage-examples/`.
   - Added `arcade-hackathon-project/` folder under `src/content/docs/`.
   
2. **Enhanced Command Table**: Updated the commands section to include new scripts and their descriptions:
   - `npm run generate-usage-examples-pages`: Generates usage example pages from `./scripts/usage-example-page-generation.cjs`.
   - `npm run check-links`: Temporarily sets `CHECK_LINKS=true`, runs `npm run build`, then resets `CHECK_LINKS=false`.
   
3. **Minor Language Adjustments**:
   - Refined the **Introduction** and **Installation** sections for better readability.

- **GitHub Stats**: Added badges for GitHub contributors, issues, pull requests, forks, and stars for both **SplashKit** and **Thoth Tech** repositories. These stats offer an at-a-glance view of project activity and community engagement.

### Motivation
The goal of these changes is to make the README more comprehensive and user-friendly, especially for new contributors and users in preparation for Trimester 3 2024.