### PR TITLE
Addition of Python Code in Using Animation Tutorials

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4538,6 +4538,7 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "extraneous": true,
       "dependencies": {
         "sprintf-js": "~1.0.2"
       }
@@ -4546,6 +4547,7 @@
       "version": "3.14.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
       "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "extraneous": true,
       "dependencies": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -4558,51 +4560,15 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
       "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+      "extraneous": true,
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/locate-path": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-      "dependencies": {
-        "p-locate": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-    },
-    "node_modules/log-symbols": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-6.0.0.tgz",
-      "integrity": "sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==",
-      "dependencies": {
-        "chalk": "^5.3.0",
-        "is-unicode-supported": "^1.3.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/log-symbols/node_modules/is-unicode-supported": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz",
-      "integrity": "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/longest-streak": {
       "version": "3.1.0",

--- a/src/content/docs/guides/Animations/0-using-animations.mdx
+++ b/src/content/docs/guides/Animations/0-using-animations.mdx
@@ -388,6 +388,64 @@ namespace UsingAnimations
 </Tabs>
 
 </TabItem>
+
+<TabItem label="python">
+
+  ```python
+  from splashkit import *
+
+open_window("Animation Test", 120, 120)
+
+# # We could load all of the resources in a bundle
+# load_resource_bundle("dance bundle", "dance_bundle.txt")
+
+# # Then access by name
+# dance_script = animation_script_named("WalkingScript")
+# frog = bitmap_named("FrogBmp")
+
+# Loading them separately
+
+# Load image and set its cell details
+frog = load_bitmap("FrogBmp", "Frog.png")
+bitmap_set_cell_details(frog, 73, 105, 4, 4, 16)  # cell width, height, cols, rows, count
+
+# Load the animation script
+dance_script = load_animation_script("WalkingScript", "kermit.txt")
+
+# Create the animation
+frog_animation = create_animation(dance_script, "WalkFront")
+
+# Create a drawing option
+opt = option_with_animation(frog_animation)
+
+# Basic event loop
+while not quit_requested():
+    process_events()
+
+    # Draw the bitmap - using opt to link to animation
+    clear_screen(color_white())
+    draw_bitmap_with_options(frog, 20, 20, opt)
+    draw_text_no_font_no_size(animation_name(frog_animation), color_black(), 0, 0)
+    refresh_screen_with_target_fps(60)
+
+    # Update the animation
+    update_animation(frog_animation)
+
+    # Switch animations
+    if key_typed(KeyCode.up_key):
+        assign_animation(frog_animation, "WalkBack")
+    elif key_typed(KeyCode.down_key):
+        assign_animation(frog_animation, "WalkFront")
+    elif key_typed(KeyCode.left_key):
+        assign_animation(frog_animation, "WalkLeft")
+    elif key_typed(KeyCode.right_key):
+        assign_animation(frog_animation, "WalkRight")
+    elif key_typed(KeyCode.d_key):
+        assign_animation(frog_animation, "Dance")
+
+close_all_windows()
+  ```
+</TabItem>
 </Tabs>
 
 ## Other Options
@@ -690,6 +748,77 @@ namespace UsingAnimations
 </TabItem>
 </Tabs>
 
+</TabItem>
+<TabItem label="python">
+
+```python
+
+from splashkit import *
+
+# Initialize the window for displaying the animation
+open_window("Animation Test", 120, 120)
+
+# Load the resource bundle (assuming "dance_bundle.txt" exists with necessary resources)
+load_resource_bundle("dance bundle", "dance_bundle.txt")
+
+# Load the animation script and the bitmap (image) by their names
+dance_script = animation_script_named("WalkingScript")  # Get the animation script named "WalkingScript"
+frog = bitmap_named("FrogBmp")  # Load the bitmap (image) named "FrogBmp"
+
+# Create the animation using the loaded dance script and the name of the animation ("WalkFront")
+frog_animation = create_animation(dance_script, "WalkFront")
+
+# Create drawing options linked to the animation
+opt = option_with_animation(frog_animation)
+
+# Main event loop
+while not quit_requested():
+    process_events()  # Process all input events (keyboard, mouse, etc.)
+
+    # Clear the screen to white before drawing new frame
+    clear_screen(color_white())
+    
+    # Draw the frog image at position (20, 20) using the animation options
+    draw_bitmap_with_options(frog, 20, 20, opt)
+    
+    # Display the current animation name (for debugging or reference)
+    draw_text(animation_name(frog_animation), color_black(), 0, 0, 24)  # Display animation name with font size 24
+    
+    # Refresh the screen at 60 FPS (frames per second)
+    refresh_screen(60)
+
+    # Update the animation for the next frame
+    update_animation(frog_animation)
+
+    # Switch animations based on key presses
+    # Use the arrow keys or the 'd' key to switch between different animations
+    if key_typed(KeyCode.up_key):  # Up arrow key
+        if key_down(KeyCode.left_shift_key):  # If left shift is held down
+            assign_animation(frog_animation, "MoonWalkBack")  # Assign "MoonWalkBack" animation
+        else:
+            assign_animation(frog_animation, "WalkBack")  # Otherwise, assign "WalkBack" animation
+    elif key_typed(KeyCode.down_key):  # Down arrow key
+        if key_down(KeyCode.left_shift_key):  # If left shift is held down
+            assign_animation(frog_animation, "MoonWalkFront")  # Assign "MoonWalkFront" animation
+        else:
+            assign_animation(frog_animation, "WalkFront")  # Otherwise, assign "WalkFront" animation
+    elif key_typed(KeyCode.left_key):  # Left arrow key
+        if key_down(KeyCode.left_shift_key):  # If left shift is held down
+            assign_animation(frog_animation, "MoonWalkLeft")  # Assign "MoonWalkLeft" animation
+        else:
+            assign_animation(frog_animation, "WalkLeft")  # Otherwise, assign "WalkLeft" animation
+    elif key_typed(KeyCode.right_key):  # Right arrow key
+        if key_down(KeyCode.left_shift_key):  # If left shift is held down
+            assign_animation(frog_animation, "MoonWalkRight")  # Assign "MoonWalkRight" animation
+        else:
+            assign_animation(frog_animation, "WalkRight")  # Otherwise, assign "WalkRight" animation
+    elif key_typed(KeyCode.d_key):  # 'd' key
+        assign_animation(frog_animation, "Dance")  # Assign "Dance" animation
+
+# Close the window when done
+close_all_windows()
+
+```
 </TabItem>
 </Tabs>
 


### PR DESCRIPTION
Added the tabs of python for both examples of Using Animation In Splashkit Tutorial

# Description

As part of Splashkit Website Expansion Team, I assigned myself the task of adding python tabs in Using Animation in Splashkit Tutorial. For both examples, python code tabs have been added along with relevant comments in code.

## Type of change

_Please delete options that are not relevant._

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation (update or new)

## How Has This Been Tested?

The newly added Code was run on local machine and the results were successful. The result screenshots have been attached.

## Testing Checklist

- [x] Tested in latest Chrome
- [x] Tested in latest Firefox
- [x] npm run build
- [x] npm run preview

## Checklist


### If involving code

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings



## Additional Notes

The Screenshots are attached
![Frog_Animation_Tutorial](https://github.com/user-attachments/assets/772ee54c-cbae-4b7d-8066-94e3f507ede6)
![Moonwalk_Tutorial_SC](https://github.com/user-attachments/assets/93d13fcb-41ab-4ab4-b4a5-383fc7c1e7d7)
