### PR TITLE
Linux install guide fix

### DIFF
--- a/src/content/docs/installation/Linux/3-splashkit.mdx
+++ b/src/content/docs/installation/Linux/3-splashkit.mdx
@@ -21,7 +21,7 @@ Follow these steps to set up SplashKit on Linux and start building interactive, 
     Open your Terminal and paste the following command to download and install SplashKit:
 
     ```shell
-    bash <(curl -s https://raw.githubusercontent.com/splashkit/skm/master/install-scripts/skm-install.sh)
+    curl -s https://raw.githubusercontent.com/splashkit/skm/master/install-scripts/skm-install.sh | bash
     ```
 
 2. **Restart the Terminal and Test the Installation**


### PR DESCRIPTION
## Summary

This PR updates the Linux install instructions to avoid forcing the script to run under `bash`. Previously, the install guide used:

```bash
bash <(curl -s https://raw.githubusercontent.com/splashkit/skm/master/install-scripts/skm-install.sh)
```

This caused issues for users running other shells (e.g. **zsh**) because the script would attempt to `source ~/.zshrc` from within `bash`, leading to a cascade of syntax errors and failed installs.

---

## Changes

* Replaced process substitution with a portable `curl | $SHELL` pattern.
* Ensures the script executes under the user’s active shell (bash, zsh, etc.) rather than always forcing `bash`.
* Improves compatibility across different Linux setups and prevents `.zshrc` from being sourced in the wrong shell.

---

## Motivation

On Linux distributions where **zsh** is the default (e.g. Arch, some custom configs), the old install command failed with errors like:

```
bad substitution
autoload: command not found
Oh My Zsh can't be loaded from: bash. You need to run zsh instead.
```

This change makes the installation process smoother and more robust across environments.

---

## Testing

* Verified installation works in **bash**.
* Verified installation works in **zsh** (with oh-my-zsh and plugins enabled).
* Confirmed `skm help` runs successfully after install.
